### PR TITLE
Narrow CI path filter to ignore non-iteration files

### DIFF
--- a/.github/workflows/auto-trigger-tests.yaml
+++ b/.github/workflows/auto-trigger-tests.yaml
@@ -21,7 +21,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
     paths:
-      - 'testing-v2/scenarios/*/iterations/**'
+      - 'testing-v2/scenarios/*/iterations/iteration-*/**'
 
 jobs:
   # Check if the latest commit is a CI evaluation commit (which should not

--- a/.github/workflows/test-iteration.yaml
+++ b/.github/workflows/test-iteration.yaml
@@ -81,7 +81,7 @@ jobs:
           # Use GitHub API to list changed files in the PR
           CHANGED=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUM}/files" \
             --jq '.[].filename' \
-            | grep '^testing-v2/scenarios/.*/iterations/' \
+            | grep '^testing-v2/scenarios/.*/iterations/iteration-' \
             | head -1)
 
           if [ -z "$CHANGED" ]; then


### PR DESCRIPTION
The iterations/** glob and grep pattern matched .gitignore and other non-iteration files, causing the test workflow to fire on unrelated PRs. Tighten both to iterations/iteration-*/**.

## Description

The iterations/** path glob and grep pattern matched .gitignore and other non-iteration files, causing the test workflow to fire on unrelated PRs. Tighten both to iterations/iteration-*/**.

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] 📝 New rule - Adding a new best practice rule
- [ ] ✏️ Rule improvement - Updating an existing rule
- [ ] 🆕 New skill - Adding an entirely new skill
- [x] 🐛 Bug fix - Fixing an issue with existing content
- [ ] 📚 Documentation - Updating README, CONTRIBUTING, or other docs
- [ ] 🔧 Build/Scripts - Changes to build process or scripts

## Checklist

<!-- Ensure you've completed these steps -->

- [ ] I have read the [Contributing Guide](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/blob/main/CONTRIBUTING.md)
- [ ] I ran `npm run validate` and it passed
- [ ] I ran `npm run build` to regenerate AGENTS.md (if adding/updating rules)
- [ ] My rule file follows the naming convention: `{prefix}-{description}.md`
- [ ] My rule includes valid frontmatter (`title`, `impact`, `tags`)

## For New Rules

<!-- Fill this out if adding a new rule, otherwise delete this section -->

**Rule file:** `skills/cosmosdb-best-practices/rules/_____.md`

**Category:** <!-- e.g., Query Optimization, Data Modeling, SDK Best Practices -->

**Impact level:** <!-- Critical / High / Medium / Low -->

**Why is this rule important?**
<!-- Explain the problem this rule addresses -->

## Testing

<!-- How did you verify this change? -->

- [ ] Tested with GitHub Copilot
- [ ] Tested with Claude Code
- [ ] Tested with Cursor
- [ ] Tested with other agent: _____
- [ ] N/A (documentation only)

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Additional Notes

<!-- Any other context or screenshots -->
