### PR TITLE
Require evaluation rules to be generic in testing v2, not scenario-specific

### DIFF
--- a/.github/workflows/aggregate-batch.yaml
+++ b/.github/workflows/aggregate-batch.yaml
@@ -453,7 +453,7 @@ jobs:
           4. Read \`testing-v2/scenarios/${SCENARIO}/api-contract.yaml\`
           5. Focus on the **Consistent Failures** section — these are tests that failed in EVERY iteration and indicate real gaps
           6. For each consistent failure, classify it per EVALUATE.md (Cosmos DB anti-pattern, unclear rule, SDK quirk, contract violation, test too strict)
-          7. For failures classified as "Cosmos DB anti-pattern" or "SDK quirk": create new rules in \`skills/cosmosdb-best-practices/rules/\`
+          7. For failures classified as "Cosmos DB anti-pattern" or "SDK quirk": create new rules in \`skills/cosmosdb-best-practices/rules/\`. **IMPORTANT: rules must be GENERIC, not scenario-specific.** The scenario is just one example. Write rules that apply to ANY application hitting the same Cosmos DB pattern. Use the scenario only as an illustrative example inside the rule body, never as the rule title or framing. A developer in a completely different domain should recognize the rule as relevant.
           8. For failures classified as "Unclear existing rule": update the existing rule to be clearer
           9. Ignore **Flaky Tests** — these are LLM stochasticity, not skill gaps
           10. Run \`npm run build\` to regenerate AGENTS.md

--- a/.github/workflows/test-iteration.yaml
+++ b/.github/workflows/test-iteration.yaml
@@ -777,7 +777,9 @@ jobs:
                 `   - **Score Summary**: per-category scores (Data Model, Partition Key, ` +
                 `Indexing, SDK Usage, Query Patterns, Overall) each X/10\n` +
                 `7. If any tests failed: classify each failure per \`testing-v2/EVALUATE.md\`, ` +
-                `create new rules if needed, update \`testing-v2/IMPROVEMENTS-LOG.md\`, ` +
+                `create new rules if needed (rules must be GENERIC — not scenario-specific; ` +
+                `any app hitting the same Cosmos DB pattern should benefit), ` +
+                `update \`testing-v2/IMPROVEMENTS-LOG.md\`, ` +
                 `run \`npm run build\`\n` +
                 `8. Commit all changes to this PR branch`;
             } else {

--- a/skills/cosmosdb-best-practices/rules/_template.md
+++ b/skills/cosmosdb-best-practices/rules/_template.md
@@ -5,6 +5,10 @@ impactDescription: Optional description of impact (e.g., "10-50x improvement")
 tags: tag1, tag2
 ---
 
+<!-- NOTE: Rules must be GENERIC. Write for any application hitting this Cosmos DB
+     pattern, not for a specific scenario. Use scenario-specific terms only as
+     illustrative examples, never in the title or top-level guidance. -->
+
 ## Rule Title Here
 
 **Impact: MEDIUM (optional impact description)**

--- a/testing-v2/EVALUATE.md
+++ b/testing-v2/EVALUATE.md
@@ -41,6 +41,17 @@ For every failing test, determine the root cause:
 
 For each failure classified as "Cosmos DB anti-pattern" or "SDK/framework quirk":
 
+> **CRITICAL: Rules must be generic, not scenario-specific.**
+> The scenario that surfaced the failure is just one example. Write rules that apply
+> to **any application** encountering the same Cosmos DB pattern. For example, if a
+> gaming-leaderboard scenario reveals the need for a shared-partition container with
+> sorted queries, write a rule about "materialized view containers with shared
+> partition keys for efficient cross-entity ORDER BY" — not a rule about "leaderboard
+> containers." Use scenario-specific terms only as illustrative examples inside the
+> rule body, never in the rule title or top-level guidance. A developer building an
+> e-commerce product-ranking page, a social-media feed, or a monitoring dashboard
+> should recognize the rule as relevant to their use case.
+
 1. **Choose the correct prefix** based on category:
    - `model-` — Data modeling (embedding, referencing, document size)
    - `partition-` — Partition key design


### PR DESCRIPTION
Add guidance to EVALUATE.md, both workflow evaluation prompts, and the rule template that rules must apply to any application hitting the same Cosmos DB pattern. Scenario-specific terms should only appear as illustrative examples, never in rule titles or top-level framing.

## Description

<!-- Briefly describe what this PR does -->

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] 📝 New rule - Adding a new best practice rule
- [ ] ✏️ Rule improvement - Updating an existing rule
- [ ] 🆕 New skill - Adding an entirely new skill
- [ ] 🐛 Bug fix - Fixing an issue with existing content
- [ ] 📚 Documentation - Updating README, CONTRIBUTING, or other docs
- [ ] 🔧 Build/Scripts - Changes to build process or scripts

## Checklist

<!-- Ensure you've completed these steps -->

- [ ] I have read the [Contributing Guide](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/blob/main/CONTRIBUTING.md)
- [ ] I ran `npm run validate` and it passed
- [ ] I ran `npm run build` to regenerate AGENTS.md (if adding/updating rules)
- [ ] My rule file follows the naming convention: `{prefix}-{description}.md`
- [ ] My rule includes valid frontmatter (`title`, `impact`, `tags`)

## For New Rules

<!-- Fill this out if adding a new rule, otherwise delete this section -->

**Rule file:** `skills/cosmosdb-best-practices/rules/_____.md`

**Category:** <!-- e.g., Query Optimization, Data Modeling, SDK Best Practices -->

**Impact level:** <!-- Critical / High / Medium / Low -->

**Why is this rule important?**
<!-- Explain the problem this rule addresses -->

## Testing

<!-- How did you verify this change? -->

- [ ] Tested with GitHub Copilot
- [ ] Tested with Claude Code
- [ ] Tested with Cursor
- [ ] Tested with other agent: _____
- [ ] N/A (documentation only)

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Additional Notes

<!-- Any other context or screenshots -->
