### PR TITLE
fix: add permissions blocks to batch workflows

### DIFF
--- a/.github/workflows/aggregate-batch.yaml
+++ b/.github/workflows/aggregate-batch.yaml
@@ -38,6 +38,10 @@ jobs:
   aggregate:
     name: Aggregate batch results
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
     # For issue_comment: only run on /aggregate commands on batch-test issues
     if: >
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/create-batch-children.yaml
+++ b/.github/workflows/create-batch-children.yaml
@@ -27,6 +27,9 @@ jobs:
   create-children:
     name: Create child iterations
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
     # For issue_comment trigger: only run on /batch-start command on batch-test issues
     if: >
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
Batch workflows lacked permissions blocks causing HTTP 403 errors. Added issues:write, contents:write, pull-requests:write as needed.