### PR TITLE
fix: add write permissions to test-iteration and auto-trigger-tests workflows

### DIFF
--- a/.github/workflows/auto-trigger-tests.yaml
+++ b/.github/workflows/auto-trigger-tests.yaml
@@ -23,6 +23,11 @@ on:
     paths:
       - 'testing-v2/scenarios/*/iterations/iteration-*/**'
 
+permissions:
+  issues: write
+  contents: write
+  pull-requests: write
+
 jobs:
   # Check if the latest commit is a CI evaluation commit (which should not
   # re-trigger the test suite). pull_request_target ignores [skip ci] in

--- a/.github/workflows/test-iteration.yaml
+++ b/.github/workflows/test-iteration.yaml
@@ -40,6 +40,11 @@ on:
   repository_dispatch:
     types: [test-iteration]
 
+permissions:
+  issues: write
+  contents: write
+  pull-requests: write
+
 jobs:
   detect-iteration:
     name: Detect changed iteration


### PR DESCRIPTION
## Problem

The upstream repo has \default_workflow_permissions: read\, so GITHUB_TOKEN in all workflows defaults to read-only. This causes 403 errors in \	est-iteration.yaml\ when trying to:
- Post test result comments on PRs (\github.rest.issues.createComment\)
- Push evaluation results back to PR branches (\git push\)

This is visible in the workflow logs:
\\\
GITHUB_TOKEN Permissions: Contents: read, Metadata: read, Packages: read
\\\
All steps that write (comment, push) then fail silently with 403.

## Fix

Add explicit \permissions:\ blocks to both affected workflows:
- \.github/workflows/auto-trigger-tests.yaml\ — workflow-level block grants the token to the called reusable workflow
- \.github/workflows/test-iteration.yaml\ — workflow-level block for standalone \workflow_dispatch\/\epository_dispatch\ invocations

Permissions added: \issues: write\, \contents: write\, \pull-requests: write\

## Context

Same root cause as the permissions fix in PR #68 (which fixed \create-batch-children.yaml\ and \ggregate-batch.yaml\).