### PR TITLE
fix(batch): prevent single-child failure when post-create issue edit …

### DIFF
--- a/.github/workflows/create-batch-children.yaml
+++ b/.github/workflows/create-batch-children.yaml
@@ -46,6 +46,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          REPO="${{ github.repository }}"
 
           # Resolve the batch issue number
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -62,7 +63,7 @@ jobs:
           echo "Batch issue: #${BATCH_ISSUE}"
 
           # Fetch the issue body
-          BODY=$(gh issue view "$BATCH_ISSUE" --json body --jq '.body')
+          BODY=$(gh issue view "$BATCH_ISSUE" --repo "$REPO" --json body --jq '.body')
 
           # Parse form fields from the issue body
           # GitHub issue forms render as: ### Label\n\nvalue\n
@@ -107,10 +108,11 @@ jobs:
 
           # Ensure required labels exist (gh issue create fails if they don't)
           for lbl in "testing" "iteration" "batch-child"; do
-            gh label create "$lbl" --color "C2E0C6" 2>/dev/null || true
+            gh label create "$lbl" --repo "$REPO" --color "C2E0C6" 2>/dev/null || true
           done
           BATCH_LABEL="batch-${BATCH_ISSUE}"
           gh label create "$BATCH_LABEL" \
+            --repo "$REPO" \
             --description "Child of batch test #${BATCH_ISSUE}" \
             --color "C2E0C6" \
             2>/dev/null || true
@@ -231,6 +233,7 @@ jobs:
             echo "Creating child issue ${i}/${ITERATIONS}: ${TITLE}"
 
             CREATE_OUTPUT=$(gh issue create \
+              --repo "$REPO" \
               --title "$TITLE" \
               --body "$ISSUE_BODY" \
               --label "testing,iteration,batch-child,${BATCH_LABEL}" 2>&1) || true
@@ -240,7 +243,20 @@ jobs:
             if [ -n "$CHILD_NUM" ]; then
               echo "  Created issue #${CHILD_NUM}"
               ISSUE_BODY_WITH_CHILD_NUM="${ISSUE_BODY//<assigned-after-create>/$CHILD_NUM}"
-              gh issue edit "$CHILD_NUM" --body "$ISSUE_BODY_WITH_CHILD_NUM" >/dev/null
+              # Newly created issues can be briefly unavailable to GraphQL lookups.
+              # Retry the body update and continue even if it ultimately fails.
+              UPDATED="false"
+              for attempt in 1 2 3 4 5; do
+                if gh issue edit "$CHILD_NUM" --repo "$REPO" --body "$ISSUE_BODY_WITH_CHILD_NUM" >/dev/null 2>&1; then
+                  UPDATED="true"
+                  break
+                fi
+                echo "  Body update retry ${attempt}/5 for issue #${CHILD_NUM}"
+                sleep 2
+              done
+              if [ "$UPDATED" != "true" ]; then
+                echo "  WARNING: Could not update body for issue #${CHILD_NUM}; continuing"
+              fi
               CHILD_ISSUES+=("$CHILD_NUM")
             else
               echo "  ERROR: Failed to create child issue for run ${i}"
@@ -254,9 +270,15 @@ jobs:
           CHILD_LIST=$(IFS=','; echo "${CHILD_ISSUES[*]}")
           echo "Child issues: ${CHILD_LIST}"
 
+          CREATED_COUNT=${#CHILD_ISSUES[@]}
+          if [ "$CREATED_COUNT" -eq 0 ]; then
+            echo "ERROR: No child issues were created"
+            exit 1
+          fi
+
           # Post summary on parent issue
           SUMMARY="## Batch Children Created\n\n"
-          SUMMARY+="Created **${ITERATIONS}** child issues for batch test #${BATCH_ISSUE}.\n\n"
+          SUMMARY+="Created **${CREATED_COUNT}** child issues for batch test #${BATCH_ISSUE}.\n\n"
           SUMMARY+="| Setting | Value |\n"
           SUMMARY+="|---------|-------|\n"
           SUMMARY+="| Scenario | ${SCENARIO} |\n"
@@ -292,5 +314,5 @@ jobs:
           SUMMARY+="A ready-to-copy \`@copilot\` evaluation prompt is posted as a comment on that PR. "
           SUMMARY+="Copy-paste it as a new comment to trigger Copilot to analyze the consistent failures and create/update rules.\n"
 
-          gh issue comment "$BATCH_ISSUE" --body "$(echo -e "$SUMMARY")"
+          gh issue comment "$BATCH_ISSUE" --repo "$REPO" --body "$(echo -e "$SUMMARY")"
           echo "Posted summary on batch issue #${BATCH_ISSUE}"


### PR DESCRIPTION
…races

Batch child creation was failing after first issue when gh issue edit hit a transient GraphQL node resolution error immediately after issue creation.

Changes:
- Make all gh issue/label/comment operations repo-explicit (--repo )
- Retry issue body update up to 5 times with backoff
- Do not abort batch if issue body update still fails after retries
- Report actual created child count in summary
- Fail only when zero child issues are created

## Description

<!-- Briefly describe what this PR does -->

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] 📝 New rule - Adding a new best practice rule
- [ ] ✏️ Rule improvement - Updating an existing rule
- [ ] 🆕 New skill - Adding an entirely new skill
- [ ] 🐛 Bug fix - Fixing an issue with existing content
- [ ] 📚 Documentation - Updating README, CONTRIBUTING, or other docs
- [ ] 🔧 Build/Scripts - Changes to build process or scripts

## Checklist

<!-- Ensure you've completed these steps -->

- [ ] I have read the [Contributing Guide](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/blob/main/CONTRIBUTING.md)
- [ ] I ran `npm run validate` and it passed
- [ ] I ran `npm run build` to regenerate AGENTS.md (if adding/updating rules)
- [ ] My rule file follows the naming convention: `{prefix}-{description}.md`
- [ ] My rule includes valid frontmatter (`title`, `impact`, `tags`)

## For New Rules

<!-- Fill this out if adding a new rule, otherwise delete this section -->

**Rule file:** `skills/cosmosdb-best-practices/rules/_____.md`

**Category:** <!-- e.g., Query Optimization, Data Modeling, SDK Best Practices -->

**Impact level:** <!-- Critical / High / Medium / Low -->

**Why is this rule important?**
<!-- Explain the problem this rule addresses -->

## Testing

<!-- How did you verify this change? -->

- [ ] Tested with GitHub Copilot
- [ ] Tested with Claude Code
- [ ] Tested with Cursor
- [ ] Tested with other agent: _____
- [ ] N/A (documentation only)

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Additional Notes

<!-- Any other context or screenshots -->
