### PR TITLE
updated readme and added a changelog for merged pr's that have direct…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,39 @@
 
 Dated history of changes to the agent kit, including the `cosmosdb-best-practices` skill (rules, categories, compiled `AGENTS.md`) and the testing framework.
 
+This is the high-level log. For detailed per-iteration evaluation notes (test results, scores, issues encountered, rules applied, lessons learned), see:
+
+- [`testing-v2/IMPROVEMENTS-LOG.md`](testing-v2/IMPROVEMENTS-LOG.md) — current testing framework (v2)
+- [`testing/IMPROVEMENTS-LOG.md`](testing/IMPROVEMENTS-LOG.md) — original testing framework (v1, historical)
+
 ---
 
-## 2026-04-07 — Rule clarifications ([#108](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/108))
+## 2026-04-18 — README updated to document testing framework
+
+- Expanded `README.md` with a section describing the testing framework and how evaluations flow back into the skill.
+
+## 2026-04-17 — CHANGELOG added
+
+- Added `CHANGELOG.md` (this file) and updated `README.md` to link to it. Backfilled entries from earlier merged PRs and from `testing/IMPROVEMENTS-LOG.md` and `testing-v2/IMPROVEMENTS-LOG.md`.
+
+## 2026-04-15 — Batch #209: Java multitenant SaaS — SDK quirk flagged, no rule changes ([#220](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/220))
+
+- Evaluated 5 Java iterations of the `multitenant-saas` scenario (testing-v2 batch #209).
+- Zero always-fail tests. When startup succeeded (3/5 iterations), pass rate was 100% across API contract, Cosmos infrastructure, and data integrity tests.
+- Identified a 40% Java startup-failure rate caused by Netty/OpenSSL behavior against the local emulator. Classified as an SDK/framework quirk, not a functional skill gap — `sdk-emulator-ssl` may benefit from a clearer programmatic Java CI bypass in a future pass.
+- No rules created or modified.
+
+## 2026-04-14 — Harness fix: guard against 1-of-0 test reporting
+
+- Fixed a batch-aggregation edge case where pytest collection errors produced a misleading "1 of 0 tests passed" summary. The harness now reports zero-test iterations explicitly.
+
+## 2026-04-09 — Website, logo, and integrations section ([#111](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/111), [#112](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/112))
+
+- Added the `docs/` agent-kit website with a GitHub-issue survey, Cosmos DB logo, Google Analytics, and metrics (70+ rules).
+- Added an "Integrations" section covering the MCP Server and Claude / Cursor plugins.
+- Converted the website submodule to a regular directory.
+
+## 2026-04-07 — README visual + rule clarifications ([#108](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/108), [#109](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/109))
 
 Expanded and clarified five existing rules so agents apply them correctly:
 
@@ -13,7 +43,8 @@ Expanded and clarified five existing rules so agents apply them correctly:
 - `query-top-literal` — reworked `TOP` vs parameterized-limit guidance.
 - `sdk-java-cosmos-config` — added missing config knobs.
 - `sdk-spring-data-annotations` — minor correctness fix.
-- Also tightened `scripts/validate.js` to catch malformed frontmatter.
+- Tightened `scripts/validate.js` to catch malformed frontmatter.
+- Added a hero image to `README.md`.
 
 ## 2026-04-03 — +10 rules, new Full-Text Search category ([#95](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/95))
 
@@ -29,47 +60,168 @@ Expanded and clarified five existing rules so agents apply them correctly:
 - Added Python and C# examples for both patterns.
 - Surfaced by the batch-191 gaming-leaderboard evaluation.
 
-## 2026-03-12 — New rules: parameterized `TOP` and composite-index directions
+## 2026-04-01 — Batch workflow fixes
+
+- Reverted explicit `permissions:` blocks that were breaking CI approval gates.
+- Fixed a race where post-create issue edits caused single-child failures in batch runs.
+
+## 2026-03-31 — CI permissions and fork workflow docs
+
+- Added required write permissions to the `test-iteration` and `auto-trigger-tests` workflows.
+- Added `permissions:` blocks to the batch workflows.
+- Documented the fork requirement and upstream-PR workflow in `README.md`.
+
+## 2026-03-30 — Batch aggregate issue→PR resolution fix
+
+- Fixed batch aggregation so parent issues resolve to the correct child PRs when iterating results.
+
+## 2026-03-27 — Five new / enhanced query and partition rules
+
+- Added `query-point-reads` ([#63](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/63)) — prefer `ReadItem` over a query when both `id` and the partition key are known.
+- Added `partition-immutable-key` ([#64](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/64)) — warns that partition keys cannot be updated in place.
+- Added `query-olap-detection` ([#61](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/61)) — warns against running analytical queries on transactional containers.
+- Enhanced `query-use-projections` ([#62](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/62)) with DTO / result-type matching guidance.
+- Enhanced `partition-hierarchical` ([#60](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/60)) with explicit broad→narrow level-ordering guidance.
+
+## 2026-03-26 — Pre-computed aggregates + tooling rules ([#58](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/58), [#59](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/59))
+
+- Added intra-document pre-computed aggregates guidance to `model-denormalize-reads`.
+- Synced the skill index and added tooling rules covering build / validate scripts.
+
+## 2026-03-24 — Jackson `@JsonIgnoreProperties` rule ([#45](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/45), [#46](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/46))
+
+- Added guidance for `@JsonIgnoreProperties` and global `ObjectMapper` config so Java code tolerates Cosmos DB system-metadata fields (`_rid`, `_self`, `_etag`, `_attachments`, `_ts`).
+- Established that evaluation-created rules must be generic, not scenario-specific.
+
+## 2026-03-23 — Java SDK and CI fixes
+
+- `sdk-java-cosmos-config` ([#44](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/44)) — added `createDatabaseIfNotExists`, fixed a `CosmosConfig` class-name collision, and added `AbstractCosmosConfiguration` guidance.
+- `query-avoid-cross-partition` ([#43](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/43)) — added a Java / Spring Data Cosmos `@Query` bypass warning.
+- `sdk-java-content-response` ([#38](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/38), [#42](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/42)) — added a Reactor NPE warning and `readItem()` / `CosmosItemResponse<T>` unwrapping guidance.
+- `sdk-spring-data-annotations` ([#41](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/41)) — partition-key-path matching warning.
+- Rule 9.1 `pattern-change-feed-materialized-views` ([#39](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/39)) — added Change Feed idempotency guidance.
+- Rule 5.2 `index-exclude-unused` ([#40](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/40)) — reordered so exclude-all-first is the primary indexing pattern.
+- CI: narrowed path filters to iteration subdirectories only ([#37](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/37)).
+
+## 2026-03-21 — testing-v2 framework merged ([#35](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/35))
+
+- Merged the `testing-v2` framework with scenarios, API contracts, infrastructure / SDK / behavioral tests, build-signal capture, deep evaluation prompts, automated commit-back, and source archiving.
+- Established `testing-v2/` as the current framework; `testing/` retained as a historical reference.
+
+## 2026-03-19 to 2026-03-20 — Batch testing framework + build-startup category
+
+- Added the batch testing framework for statistical significance (multiple iterations per scenario).
+- `/batch-start` comment replaces assign-Copilot as the batch trigger; auto-create labels and auto-generate `/aggregate` commands with child-issue numbers.
+- Aggregate fixes: iterate runs to find test artifacts, correct issue→PR resolution, per-category stats.
+- Added a deep-evaluation step to the batch flow and next-steps instructions in the batch issue body.
+- Exposed `build_startup` as a visible test category in reports; fixed summary-PR creation and skipped it for control runs; added auto-generation to `create-scenario`.
+
+## 2026-03-18 — Test + CI hardening
+
+- Added the missing `test_status_query_returns_correct_results` flow using a fresh order and the correct API path.
+- Removed `permissions:` / `concurrency:` blocks from CI workflows to match org settings.
+- Documented the manual workflow-approval step and why full automation requires a PAT.
+- Fixed the control-run re-trigger loop and made archiving conditional.
+
+## 2026-03-16 — Infrastructure and SDK tests; test-category docs
+
+- Added infrastructure tests for `ai-chat-rag` and `multitenant-saas`; updated the scenario-creation recipe.
+- Added infrastructure / SDK tests and build-signal capture for all scenarios.
+- Documented test categories and build signals in the testing README.
+
+## 2026-03-14 — Harder behavioral contracts + robustness tests
+
+- Expanded API contracts across all three v2 scenarios with harder-to-implement behaviors.
+- Added robustness tests to catch real application bugs.
+- Added `__pycache__` to `.gitignore`.
+
+## 2026-03-13 — Java SSL fix + CI reliability + skills toggle
+
+- Java emulator SSL: import the Cosmos DB Emulator cert into the Java truststore.
+- Enabled Copilot auto-retry (`workflow_call` + detailed CI logs).
+- Language-aware common-cause hints + copy-paste `@copilot` prompts.
+- Added a skills toggle, deep-evaluation prompt, and control-run support.
+- Added automated evaluation, source archiving, and commit-back steps.
+- Fixed multiple CI issues: batch-file launcher, hidden-window app launch, system-proxy bypass, `127.0.0.1` to avoid IPv6 timeouts on Windows, explicit `--ref` dispatch, improved emulator retries.
+
+## 2026-03-12 — New rules: parameterized `TOP` and composite-index directions + CI switch
 
 - Added `query-top-literal` — `TOP` requires a literal integer; `@param` causes 400 Bad Request.
 - Added `index-composite-direction` — composite-index directions must match `ORDER BY`; define both ASC and DESC variants.
 - Found via gaming-leaderboard iteration-001-python (testing-v2 PR #4).
+- Switched CI to the Windows emulator and added a gatekeeper workflow.
+- Auto-trigger tests for Copilot PRs; support `workflow_dispatch` / `repository_dispatch`.
+- Improved emulator polling, emoji encoding, and emulator-failure reporting.
 
-## 2026-03-11 — New rule: Python async SDK deps
+## 2026-03-11 — testing-v2 automation + Python async SDK rule
 
-- Added `sdk-python-async-deps` (rule 4.15) — `azure.cosmos.aio.CosmosClient` requires `aiohttp` to be in `requirements.txt`; `aiohttp` is an optional dependency of `azure-cosmos`.
+- Added `sdk-python-async-deps` (rule 4.15) — `azure.cosmos.aio.CosmosClient` requires `aiohttp` in `requirements.txt`.
 - Found via gaming-leaderboard iteration-001-python (testing-v2 PR #2).
+- Added testing-v2 automation: issue templates, CI workflow, recipes, and 5 scenarios.
+- Auto-trigger `@copilot` for startup and test failures; handle app-startup failures gracefully in CI.
 
-## 2026-03-02 — Fixed Python ETag example
+## 2026-03-03 — SDK version currency rule
+
+- Added `sdk-validate-version-currency` — best practice for validating that the Cosmos DB SDK version in use is current.
+
+## 2026-03-02 — Fixed Python ETag example ([#21](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/21), [#22](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/22))
 
 - Corrected the Python example in `sdk-etag-concurrency`: must use `MatchConditions.IfNotModified` from `azure.core`, not the raw ETag string. The previous example raised `TypeError: Invalid match condition` at runtime.
+- Added iteration-003-python for gaming-leaderboard (9/10).
+- Cleaned up iterations (restored missing source-code zip for ecommerce-order-api iteration-004).
 
-## 2026-02-18 — Multi-tenant SaaS (Java) rule additions and strengthening
+## 2026-02-25 — JPA → Spring Data Cosmos rules ([#20](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/20))
+
+- Added best-practice rules for migrating JPA code to Spring Data Cosmos DB.
+
+## 2026-02-20 — Hot partition example ([#19](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/19))
+
+- Updated `partition-avoid-hotspots` with a worked example for popularity skew; recompiled `AGENTS.md`.
+
+## 2026-02-19 — Data modeling / partitioning / change feed expansions
+
+- Added examples, anti-patterns, and extra guidance to the data-modeling, partitioning, and change-feed / materialized-view rules.
+- Cosmetic and syntax updates to `model-type-discriminator`, `partition-avoid-hotspots`, `partition-synthetic-keys`, and `pattern-change-feed-materialized-views`; recompiled `AGENTS.md`.
+
+## 2026-02-18 — Multi-tenant SaaS (Java) rule additions and strengthening + Claude Code plugin ([#16](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/16), [#17](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/17), [#18](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/18))
 
 - Added `sdk-java-cosmos-config` — documents the `@PostConstruct` + `@Bean` circular-dependency anti-pattern in Spring Boot and the correct chained-`@Bean` pattern.
 - Strengthened `index-composite` with multi-tenant patterns and composite indexes for type-discriminator queries.
 - Strengthened `query-pagination` with an explicit unbounded-query anti-pattern.
 - Strengthened `sdk-etag-concurrency` with a "denormalized data updates" section and Java examples.
+- Added Cosmos DB model constraints (PR #16); `AGENTS.md` recompiled to 61 rules.
+- Added Claude Code plugin metadata for marketplace installation (PR #18).
 
-## 2026-02-17 — Gaming leaderboard rule additions
+## 2026-02-17 — Gaming leaderboard rule additions ([#15](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/15))
 
 - Added `pattern-efficient-ranking` — replaces O(N) full-partition rank scans with COUNT-based, change-feed pre-computed, or score-bucket approaches.
 - Added `sdk-etag-concurrency` — ETag-based optimistic concurrency for read-modify-write operations, with .NET, Java, and Python examples.
 
-## 2026-02-02 — Multi-tenant SaaS (.NET) rule addition
+## 2026-02-02 — Multi-tenant SaaS (.NET) rule addition ([#14](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/14))
 
 - Added `sdk-newtonsoft-dependency` — explicit `Newtonsoft.Json >= 13.0.3` requirement (security + version-conflict guidance), even when using `System.Text.Json`.
 
-## 2026-01-29 — Vector Search category created
+## 2026-01-29 — Vector Search category + IoT telemetry iterations ([#11](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/11))
 
-- Created the **Vector Search** category from scratch (rules 10.1–10.4):
-  - `vector-enable-feature` — account-level capability flag and SDK version requirements.
-  - `vector-embedding-policy` — `VectorEmbeddingPolicy` (path, dataType, dimensions, distanceFunction); cannot be modified post-create.
-  - `vector-index-type` — `QuantizedFlat` vs `DiskANN`; vector paths **must** be excluded from regular indexing.
-  - `vector-distance-query` — `VectorDistance()` query patterns and parameterization.
-- Same day, added two more vector rules from the Python/Azure validation pass:
-  - `vector-repository-pattern` — full repository-layer implementation pattern.
-  - `vector-normalize-embeddings` — L2 normalization for cosine similarity (production and deterministic test embeddings).
+Created the **Vector Search** category from scratch (rules 10.1–10.4):
+
+- `vector-enable-feature` — account-level capability flag and SDK version requirements.
+- `vector-embedding-policy` — `VectorEmbeddingPolicy` (path, dataType, dimensions, distanceFunction); cannot be modified post-create.
+- `vector-index-type` — `QuantizedFlat` vs `DiskANN`; vector paths **must** be excluded from regular indexing.
+- `vector-distance-query` — `VectorDistance()` query patterns and parameterization.
+
+Same day, added two more vector rules from the Python / Azure validation pass:
+
+- `vector-repository-pattern` — full repository-layer implementation pattern.
+- `vector-normalize-embeddings` — L2 normalization for cosine similarity (production and deterministic test embeddings).
+
+Also ran `iot-device-telemetry` end-to-end across three languages:
+
+- **001 — .NET (9.5/10):** 30+ rules applied correctly (hierarchical partition key, synthetic key, composite indexes, autoscale, TTL, singleton client). No rule gaps.
+- **002 — Java / Spring Boot (8/10):** Build only succeeded after fixing a Java-version / Spring Boot 3.x mismatch and updating to the current `PartitionKeyDefinition` + `MULTI_HASH` / V2 API.
+- **003 — Python / FastAPI (9/10):** Validated `sdk-local-dev-config` (`load_dotenv(override=True)`) and confirmed the Python SDK requires `ThroughputProperties(auto_scale_max_throughput=...)` instead of a dict.
+
+No new rules from IoT iterations — existing rule set covered all observed issues. Also updated the install command to use `skills add` ([#12](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/12)).
 
 ## 2026-01-28 — Cross-iteration review: design patterns + emulator/SDK fixes
 
@@ -77,16 +229,31 @@ Expanded and clarified five existing rules so agents apply them correctly:
 - Added `sdk-java-content-response` — Java SDK returns `null` from `createItem` unless `contentResponseOnWriteEnabled(true)` is set.
 - Added `sdk-local-dev-config` — `load_dotenv(override=True)` and startup endpoint logging to prevent system env vars from silently pointing local dev at production.
 - Enhanced `sdk-emulator-ssl` to cover .NET, Python, and Node.js (previously Java-only).
+- Added iteration-002-dotnet validating skills on `ecommerce-order-api`.
 
-## 2026-01-27 — Initial iteration findings (ecommerce-order-api)
+## 2026-01-27 — Testing framework born + first rule from iteration findings
 
-- Added `sdk-serialization-enums` — fixes a real bug where the .NET SDK stored enums as integers while queries searched for strings, causing status queries to return empty results.
+- Added `sdk-serialization-enums` — fixes a real bug where the .NET SDK stored enums as integers while queries searched for strings, causing status queries to return empty results (ecommerce-order-api baseline).
+- Established that every test iteration must load the `cosmosdb-best-practices` skill before code generation — otherwise the iteration is a baseline, not a skill test. Updated `testing/README.md` and the iteration template to require a "Skills Verification" step. Iteration-001-dotnet of `ecommerce-order-api` was retroactively marked as the baseline (no skills).
+
+## 2026-01-23 — Contribution scaffolding
+
+- Added a pull-request template, `CONTRIBUTING.md` reference from `README.md`, and post-install / welcome scripts.
+- Simplified the installation story: removed the CLI script and post-install script in favor of `skills add`.
+
+## 2026-01-22 — High-availability and SDK resilience rules
+
+- Added four rules for high availability and SDK resilience (connection modes, retry / backoff, regional failover, client reuse).
+
+## 2026-01-21 — Initial release
+
+- Initial release of the `cosmosdb-best-practices` agent skill: rule set, `SKILL.md`, compiled `AGENTS.md`, build / validate scripts, and README setup instructions.
 
 ---
 
 ## How to update
 
-When a PR changes anything under `skills/cosmosdb-best-practices/` (rules or compiled `AGENTS.md`), add an entry at the top:
+When a PR changes anything under `skills/cosmosdb-best-practices/` (rules or compiled `AGENTS.md`), or completes a notable testing iteration or batch evaluation, add an entry at the top:
 
 ```
 ## YYYY-MM-DD — short summary ([#NNN](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/NNN))
@@ -94,4 +261,4 @@ When a PR changes anything under `skills/cosmosdb-best-practices/` (rules or com
 - What changed / why it matters.
 ```
 
-If the change came out of a testing iteration, include a short summary here and put the full evaluation detail in `testing-v2/IMPROVEMENTS-LOG.md`.
+Keep entries concise — a few bullets summarizing the change and the trigger (scenario / iteration / batch). Put the full evaluation detail in `testing-v2/IMPROVEMENTS-LOG.md` (or `testing/IMPROVEMENTS-LOG.md` for historical v1 entries) and link from the changelog if useful.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,13 +52,13 @@ Expanded and clarified five existing rules so agents apply them correctly:
 - Added a brand-new **Full-Text Search** category with 6 rules (12.1–12.6) covering the capability flag, `fullTextPolicy`, `fullTextIndexes`, BM25 ranking, keyword matching, and hybrid queries.
 - Skill now totals 89 rules across 12 categories.
 
-## 2026-04-02 — Cascade delete/update guidance ([#208](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/208))
+## 2026-04-02 — Cascade delete/update guidance + first batch run ([#208](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/208))
 
-- Extended `model-denormalize-reads` with explicit cascade semantics:
+- **First batch run: Batch #191** (`gaming-leaderboard`, Python, skills loaded) — 5 iterations aggregated through the new batch pipeline end-to-end, producing the first statistical evaluation and validating the framework.
+- Extended `model-denormalize-reads` with explicit cascade semantics surfaced by that batch:
   - Deleting a source document must also delete all derived/embedded copies in other containers.
   - Updating a field used as a partition key in derived containers requires delete-and-recreate in the new partition.
 - Added Python and C# examples for both patterns.
-- Surfaced by the batch-191 gaming-leaderboard evaluation.
 
 ## 2026-04-01 — Batch workflow fixes
 
@@ -103,15 +103,19 @@ Expanded and clarified five existing rules so agents apply them correctly:
 - Rule 5.2 `index-exclude-unused` ([#40](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/40)) — reordered so exclude-all-first is the primary indexing pattern.
 - CI: narrowed path filters to iteration subdirectories only ([#37](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/37)).
 
-## 2026-03-21 — testing-v2 framework merged ([#35](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/35))
+## 2026-03-21 — Testing framework v2 merged ([#35](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/35))
 
-- Merged the `testing-v2` framework with scenarios, API contracts, infrastructure / SDK / behavioral tests, build-signal capture, deep evaluation prompts, automated commit-back, and source archiving.
-- Established `testing-v2/` as the current framework; `testing/` retained as a historical reference.
+- **Testing framework v2** ([`testing-v2/`](testing-v2/)): merged the next-generation framework that replaces manual iteration runs with an automated CI harness.
+  - Harness: `testing-v2/harness/report.py`, `evaluate.py`, `aggregate.py`, `conftest_base.py` (shared pytest fixtures).
+  - Machine-readable **API contracts** (`api-contract.yaml`) per scenario, so tests are generated from the contract instead of re-written per iteration.
+  - Infrastructure, SDK, and behavioral test categories; build-signal capture; deep-evaluation prompts; automated commit-back and source archiving.
+  - GitHub Actions workflow `test-iteration.yaml` drives each iteration end-to-end (spin up emulator → Copilot generates code → run tests → post results → archive).
+- `testing-v2/` becomes the current framework; `testing/` is retained as a historical reference.
 
-## 2026-03-19 to 2026-03-20 — Batch testing framework + build-startup category
+## 2026-03-19 to 2026-03-20 — Batch testing capability + build-startup category
 
-- Added the batch testing framework for statistical significance (multiple iterations per scenario).
-- `/batch-start` comment replaces assign-Copilot as the batch trigger; auto-create labels and auto-generate `/aggregate` commands with child-issue numbers.
+- **Batch testing capability** added for statistical significance (multiple iterations per scenario per run). New workflows: `create-batch-children.yaml` fans a batch issue into N child iteration issues; `auto-trigger-tests.yaml` kicks off CI for each child PR.
+- `/batch-start` comment replaces assign-Copilot as the batch trigger; labels are auto-created; `/aggregate` commands are auto-generated with child-issue numbers.
 - Aggregate fixes: iterate runs to find test artifacts, correct issue→PR resolution, per-category stats.
 - Added a deep-evaluation step to the batch flow and next-steps instructions in the batch issue body.
 - Exposed `build_startup` as a visible test category in reports; fixed summary-PR creation and skipped it for control runs; added auto-generation to `create-scenario`.
@@ -155,10 +159,10 @@ Expanded and clarified five existing rules so agents apply them correctly:
 
 ## 2026-03-11 — testing-v2 automation + Python async SDK rule
 
-- Added `sdk-python-async-deps` (rule 4.15) — `azure.cosmos.aio.CosmosClient` requires `aiohttp` in `requirements.txt`.
-- Found via gaming-leaderboard iteration-001-python (testing-v2 PR #2).
-- Added testing-v2 automation: issue templates, CI workflow, recipes, and 5 scenarios.
+- **CI automation scaffolding** for testing-v2: issue templates (Run Test Iteration, Create New Scenario), the `test-iteration.yaml` CI workflow, the recipes (`CREATE-SCENARIO.md`, `EVALUATE.md`), and the initial five v2 scenarios migrated from v1.
+- Added a **Python-dependency-verification step** in CI so missing optional dependencies fail fast at startup instead of producing confusing test errors.
 - Auto-trigger `@copilot` for startup and test failures; handle app-startup failures gracefully in CI.
+- Added `sdk-python-async-deps` (rule 4.15) — `azure.cosmos.aio.CosmosClient` requires `aiohttp` in `requirements.txt`. Found via gaming-leaderboard iteration-001-python (testing-v2 PR #2).
 
 ## 2026-03-03 — SDK version currency rule
 
@@ -231,10 +235,11 @@ No new rules from IoT iterations — existing rule set covered all observed issu
 - Enhanced `sdk-emulator-ssl` to cover .NET, Python, and Node.js (previously Java-only).
 - Added iteration-002-dotnet validating skills on `ecommerce-order-api`.
 
-## 2026-01-27 — Testing framework born + first rule from iteration findings
+## 2026-01-27 — Testing framework v1 created + first rule from iteration findings
 
-- Added `sdk-serialization-enums` — fixes a real bug where the .NET SDK stored enums as integers while queries searched for strings, causing status queries to return empty results (ecommerce-order-api baseline).
-- Established that every test iteration must load the `cosmosdb-best-practices` skill before code generation — otherwise the iteration is a baseline, not a skill test. Updated `testing/README.md` and the iteration template to require a "Skills Verification" step. Iteration-001-dotnet of `ecommerce-order-api` was retroactively marked as the baseline (no skills).
+- **Testing framework v1** ([`testing/`](testing/)): added the initial framework — `testing/README.md`, the iteration template (`_iteration-template.md`), the scenario template (`_scenario-template.md`), and the first five scenarios (`ecommerce-order-api`, `gaming-leaderboard`, `iot-device-telemetry`, `ai-chat-rag`, `multitenant-saas`). Iterations were run manually and documented per-folder.
+- Established that every iteration must load the `cosmosdb-best-practices` skill before code generation — otherwise the iteration is a baseline, not a skill test. Added a "Skills Verification" step to the iteration template. Iteration-001-dotnet of `ecommerce-order-api` was retroactively marked as the baseline (no skills).
+- Added `sdk-serialization-enums` — fixes a real bug where the .NET SDK stored enums as integers while queries searched for strings, causing status queries to return empty results (first rule sourced from iteration findings).
 
 ## 2026-01-23 — Contribution scaffolding
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-Improvements to the `cosmosdb-best-practices` skill (rules and compiled `AGENTS.md`). Harness, docs site, and CI-only changes are intentionally omitted.
+Dated history of changes to the agent kit, including the `cosmosdb-best-practices` skill (rules, categories, compiled `AGENTS.md`) and the testing framework.
+
+---
 
 ## 2026-04-07 — Rule clarifications ([#108](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/108))
 
@@ -25,7 +27,60 @@ Expanded and clarified five existing rules so agents apply them correctly:
   - Deleting a source document must also delete all derived/embedded copies in other containers.
   - Updating a field used as a partition key in derived containers requires delete-and-recreate in the new partition.
 - Added Python and C# examples for both patterns.
-- Gap was surfaced by the batch-191 gaming-leaderboard evaluation.
+- Surfaced by the batch-191 gaming-leaderboard evaluation.
+
+## 2026-03-12 — New rules: parameterized `TOP` and composite-index directions
+
+- Added `query-top-literal` — `TOP` requires a literal integer; `@param` causes 400 Bad Request.
+- Added `index-composite-direction` — composite-index directions must match `ORDER BY`; define both ASC and DESC variants.
+- Found via gaming-leaderboard iteration-001-python (testing-v2 PR #4).
+
+## 2026-03-11 — New rule: Python async SDK deps
+
+- Added `sdk-python-async-deps` (rule 4.15) — `azure.cosmos.aio.CosmosClient` requires `aiohttp` to be in `requirements.txt`; `aiohttp` is an optional dependency of `azure-cosmos`.
+- Found via gaming-leaderboard iteration-001-python (testing-v2 PR #2).
+
+## 2026-03-02 — Fixed Python ETag example
+
+- Corrected the Python example in `sdk-etag-concurrency`: must use `MatchConditions.IfNotModified` from `azure.core`, not the raw ETag string. The previous example raised `TypeError: Invalid match condition` at runtime.
+
+## 2026-02-18 — Multi-tenant SaaS (Java) rule additions and strengthening
+
+- Added `sdk-java-cosmos-config` — documents the `@PostConstruct` + `@Bean` circular-dependency anti-pattern in Spring Boot and the correct chained-`@Bean` pattern.
+- Strengthened `index-composite` with multi-tenant patterns and composite indexes for type-discriminator queries.
+- Strengthened `query-pagination` with an explicit unbounded-query anti-pattern.
+- Strengthened `sdk-etag-concurrency` with a "denormalized data updates" section and Java examples.
+
+## 2026-02-17 — Gaming leaderboard rule additions
+
+- Added `pattern-efficient-ranking` — replaces O(N) full-partition rank scans with COUNT-based, change-feed pre-computed, or score-bucket approaches.
+- Added `sdk-etag-concurrency` — ETag-based optimistic concurrency for read-modify-write operations, with .NET, Java, and Python examples.
+
+## 2026-02-02 — Multi-tenant SaaS (.NET) rule addition
+
+- Added `sdk-newtonsoft-dependency` — explicit `Newtonsoft.Json >= 13.0.3` requirement (security + version-conflict guidance), even when using `System.Text.Json`.
+
+## 2026-01-29 — Vector Search category created
+
+- Created the **Vector Search** category from scratch (rules 10.1–10.4):
+  - `vector-enable-feature` — account-level capability flag and SDK version requirements.
+  - `vector-embedding-policy` — `VectorEmbeddingPolicy` (path, dataType, dimensions, distanceFunction); cannot be modified post-create.
+  - `vector-index-type` — `QuantizedFlat` vs `DiskANN`; vector paths **must** be excluded from regular indexing.
+  - `vector-distance-query` — `VectorDistance()` query patterns and parameterization.
+- Same day, added two more vector rules from the Python/Azure validation pass:
+  - `vector-repository-pattern` — full repository-layer implementation pattern.
+  - `vector-normalize-embeddings` — L2 normalization for cosine similarity (production and deterministic test embeddings).
+
+## 2026-01-28 — Cross-iteration review: design patterns + emulator/SDK fixes
+
+- Added the **Design Patterns** category (section 9) and `pattern-change-feed-materialized-views` — converts cross-partition admin queries into single-partition lookups via Change Feed.
+- Added `sdk-java-content-response` — Java SDK returns `null` from `createItem` unless `contentResponseOnWriteEnabled(true)` is set.
+- Added `sdk-local-dev-config` — `load_dotenv(override=True)` and startup endpoint logging to prevent system env vars from silently pointing local dev at production.
+- Enhanced `sdk-emulator-ssl` to cover .NET, Python, and Node.js (previously Java-only).
+
+## 2026-01-27 — Initial iteration findings (ecommerce-order-api)
+
+- Added `sdk-serialization-enums` — fixes a real bug where the .NET SDK stored enums as integers while queries searched for strings, causing status queries to return empty results.
 
 ---
 
@@ -38,3 +93,5 @@ When a PR changes anything under `skills/cosmosdb-best-practices/` (rules or com
 
 - What changed / why it matters.
 ```
+
+If the change came out of a testing iteration, include a short summary here and put the full evaluation detail in `testing-v2/IMPROVEMENTS-LOG.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+Improvements to the `cosmosdb-best-practices` skill (rules and compiled `AGENTS.md`). Harness, docs site, and CI-only changes are intentionally omitted.
+
+## 2026-04-07 — Rule clarifications ([#108](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/108))
+
+Expanded and clarified five existing rules so agents apply them correctly:
+
+- `partition-hierarchical` — clearer guidance on when to use hierarchical partition keys.
+- `query-pagination` — expanded pagination patterns and anti-patterns.
+- `query-top-literal` — reworked `TOP` vs parameterized-limit guidance.
+- `sdk-java-cosmos-config` — added missing config knobs.
+- `sdk-spring-data-annotations` — minor correctness fix.
+- Also tightened `scripts/validate.js` to catch malformed frontmatter.
+
+## 2026-04-03 — +10 rules, new Full-Text Search category ([#95](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/95))
+
+- Added 4 new SDK rules (4.21–4.24).
+- Added a brand-new **Full-Text Search** category with 6 rules (12.1–12.6) covering the capability flag, `fullTextPolicy`, `fullTextIndexes`, BM25 ranking, keyword matching, and hybrid queries.
+- Skill now totals 89 rules across 12 categories.
+
+## 2026-04-02 — Cascade delete/update guidance ([#208](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/208))
+
+- Extended `model-denormalize-reads` with explicit cascade semantics:
+  - Deleting a source document must also delete all derived/embedded copies in other containers.
+  - Updating a field used as a partition key in derived containers requires delete-and-recreate in the new partition.
+- Added Python and C# examples for both patterns.
+- Gap was surfaced by the batch-191 gaming-leaderboard evaluation.
+
+---
+
+## How to update
+
+When a PR changes anything under `skills/cosmosdb-best-practices/` (rules or compiled `AGENTS.md`), add an entry at the top:
+
+```
+## YYYY-MM-DD — short summary ([#NNN](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/pull/NNN))
+
+- What changed / why it matters.
+```

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for a dated history of improvements to the skills themselves (new rules, rule clarifications, new categories).
+See [CHANGELOG.md](CHANGELOG.md) for a dated history of updates to the agent kit, including the `cosmosdb-best-practices` skill and the testing framework. Each entry links to the PR that introduced the change.
 
-Each entry links to the PR that introduced the change. When you merge a PR that adds or updates a rule, add a new dated entry at the top.
+When you merge a PR, add a new dated entry at the top of `CHANGELOG.md`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Works with Claude Code, GitHub Copilot, Gemini CLI, and other Agent Skills-compa
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a dated history of improvements to the skills themselves (new rules, rule clarifications, new categories).
+
+Each entry links to the PR that introduced the change. When you merge a PR that adds or updates a rule, add a new dated entry at the top.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Skills follow the [Agent Skills](https://agentskills.io/) format.
 
 ### cosmosdb-best-practices
 
-Azure Cosmos DB performance optimization guidelines containing 45+ rules across 8 categories, prioritized by impact.
+Azure Cosmos DB performance optimization guidelines containing 90+ rules across 12 categories, prioritized by impact.
 
 **Use when:**
 - Writing new code that interacts with Cosmos DB

--- a/skills/cosmosdb-best-practices/README.md
+++ b/skills/cosmosdb-best-practices/README.md
@@ -4,7 +4,7 @@ Azure Cosmos DB best practices for AI coding agents, following the [Agent Skills
 
 ## Overview
 
-This skill contains 75+ rules across 11 categories, ordered by impact:
+This skill contains 89 rules across 12 categories, ordered by impact:
 
 | Category | Impact | Description |
 |----------|--------|-------------|
@@ -19,6 +19,7 @@ This skill contains 75+ rules across 11 categories, ordered by impact:
 | Design Patterns | HIGH | Reusable Cosmos DB architecture patterns |
 | Developer Tooling | MEDIUM | Emulator and extension guidance for day-to-day work |
 | Vector Search | HIGH | Semantic search and RAG-related configuration |
+| Full-Text Search | HIGH | Keyword matching, BM25 ranking, and hybrid search configuration |
 
 ## Installation
 
@@ -66,7 +67,8 @@ skills/cosmosdb-best-practices/
     ├── monitoring-*.md   # Monitoring rules
     ├── pattern-*.md      # Design pattern rules
     ├── tooling-*.md      # Developer tooling rules
-    └── vector-*.md       # Vector search rules
+    ├── vector-*.md       # Vector search rules
+    └── fts-*.md          # Full-text search rules
 ```
 
 ## How It Works


### PR DESCRIPTION
## Description

Updates the `cosmosdb-best-practices` README to reflect the current state of the skill. The rule count and category count were out of date (said "75+ rules across 11 categories") and did not list the Full-Text Search category added in #95.

## Reasoning 
Was recommended by @aliuy we add a changelog.  Updated the README with the most current info.

## Type of Change

- [ ] 📝 New rule - Adding a new best practice rule
- [ ] ✏️ Rule improvement - Updating an existing rule
- [ ] 🆕 New skill - Adding an entirely new skill
- [ ] 🐛 Bug fix - Fixing an issue with existing content
- [x] 📚 Documentation - Updating README, CONTRIBUTING, or other docs
- [ ] 🔧 Build/Scripts - Changes to build process or scripts

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/blob/main/CONTRIBUTING.md)
- [ ] I ran `npm run validate` and it passed
- [ ] I ran `npm run build` to regenerate AGENTS.md (if adding/updating rules)
- [ ] My rule file follows the naming convention: `{prefix}-{description}.md`
- [ ] My rule includes valid frontmatter (`title`, `impact`, `tags`)

## For New Rules

N/A — documentation-only change.

## Testing

- [ ] Tested with GitHub Copilot
- [ ] Tested with Claude Code
- [ ] Tested with Cursor
- [ ] Tested with other agent: _____
- [x] N/A (documentation only)

## Related Issues

N/A

## Additional Notes

Changes in `skills/cosmosdb-best-practices/README.md`:

- Overview now reads **89 rules across 12 categories** (was "75+ rules across 11 categories").
- Added a **Full-Text Search** row to the category table (HIGH impact — keyword matching, BM25 ranking, hybrid search).
- Added `fts-*.md` to the rule file-structure listing.

No rule files or `AGENTS.md` were modified, so no rebuild was needed.