### PR TITLE
fix: Go/Rust startup failure on Windows CI (cmd.exe path and .exe issues)

### DIFF
--- a/.github/workflows/test-iteration.yaml
+++ b/.github/workflows/test-iteration.yaml
@@ -451,6 +451,14 @@ jobs:
         run: |
           $runCmd = "${{ steps.config.outputs.run_cmd }}"
 
+          # Normalise Unix-style paths for Windows cmd.exe:
+          #   ./server  -> .\server    (forward-slash is a switch delimiter in cmd)
+          # Also ensure compiled Go/Rust binaries have .exe extension.
+          $runCmd = $runCmd -replace '^\./', '.\\'
+          if ($runCmd -match '^\.\\[\w\-]+$' -and -not $runCmd.EndsWith('.exe')) {
+            $runCmd += '.exe'
+          }
+
           $stdoutLog = Join-Path $PWD "app-output.log"
           $stderrLog = Join-Path $PWD "app-error.log"
 

--- a/testing-v2/README.md
+++ b/testing-v2/README.md
@@ -652,7 +652,7 @@ The test runner is always Python (pytest + requests). The **app under test** can
 | .NET 8 | ASP.NET Web API | 5000 | `dotnet build` | `dotnet run` |
 | Java | Spring Boot 3 | 8080 | `mvn package -DskipTests` | `java -jar target/*.jar` |
 | Node.js | Express | 3000 | `npm install` | `node server.js` |
-| Go | Gin | 8080 | `go build -o server .` | `./server` |
+| Go | Gin | 8080 | `go build -o server.exe .` | `.\server.exe` |
 
 Configure per-iteration via `iteration-config.yaml`.
 

--- a/testing-v2/scenarios/_iteration-config-template.yaml
+++ b/testing-v2/scenarios/_iteration-config-template.yaml
@@ -26,7 +26,7 @@ health: /health
 #   dotnet:  dotnet build
 #   java:    mvn package -DskipTests
 #   nodejs:  npm install
-#   go:      go build -o app .
+#   go:      go build -o app.exe .
 #   rust:    cargo build --release
 build: pip install -r requirements.txt
 
@@ -41,8 +41,8 @@ build: pip install -r requirements.txt
 #   dotnet:  dotnet run --urls http://localhost:8080
 #   java:    java -jar target/app.jar --server.port=8080
 #   nodejs:  node server.js
-#   go:      ./app
-#   rust:    ./target/release/app
+#   go:      .\app.exe
+#   rust:    .\target\release\app.exe
 run: python app.py
 
 # Whether the agent loaded skills/cosmosdb-best-practices/AGENTS.md before

--- a/testing-v2/scenarios/ai-chat-rag/SCENARIO.md
+++ b/testing-v2/scenarios/ai-chat-rag/SCENARIO.md
@@ -394,8 +394,8 @@ language: go
 database: ai-chat-rag
 port: 8080
 health: /health
-build: go build -o server .
-run: ./server
+build: go build -o server.exe .
+run: .\server.exe
 ```
 
 The Cosmos DB connection uses environment variables:

--- a/testing-v2/scenarios/ecommerce-order-api/SCENARIO.md
+++ b/testing-v2/scenarios/ecommerce-order-api/SCENARIO.md
@@ -411,8 +411,8 @@ language: go
 database: ecommerce-order-api
 port: 8080
 health: /health
-build: go build -o server .
-run: ./server
+build: go build -o server.exe .
+run: .\server.exe
 ```
 
 The Cosmos DB connection uses environment variables:

--- a/testing-v2/scenarios/gaming-leaderboard/SCENARIO.md
+++ b/testing-v2/scenarios/gaming-leaderboard/SCENARIO.md
@@ -415,8 +415,8 @@ language: go
 database: gaming-leaderboard
 port: 8080
 health: /health
-build: go build -o server .
-run: ./server
+build: go build -o server.exe .
+run: .\server.exe
 ```
 
 The Cosmos DB connection uses environment variables:

--- a/testing-v2/scenarios/iot-device-telemetry/SCENARIO.md
+++ b/testing-v2/scenarios/iot-device-telemetry/SCENARIO.md
@@ -416,8 +416,8 @@ language: go
 database: iot-device-telemetry
 port: 8080
 health: /health
-build: go build -o server .
-run: ./server
+build: go build -o server.exe .
+run: .\server.exe
 ```
 
 The Cosmos DB connection uses environment variables:

--- a/testing-v2/scenarios/multitenant-saas/SCENARIO.md
+++ b/testing-v2/scenarios/multitenant-saas/SCENARIO.md
@@ -430,8 +430,8 @@ language: go
 database: multitenant-saas
 port: 8080
 health: /health
-build: go build -o server .
-run: ./server
+build: go build -o server.exe .
+run: .\server.exe
 ```
 
 The Cosmos DB connection uses environment variables:


### PR DESCRIPTION
## Description

For testing framework V2, build succeeds but app never starts. This affects Go and would also affect Rust.

### Root cause

The CI runs on Windows (required for the Cosmos DB Emulator). The startup step writes the run command into a `.cmd` batch file. Two issues with Unix-style commands:

1. `./server` — `cmd.exe` interprets `/` as a switch delimiter, not a path separator
2. `go build -o server .` produces a file with no `.exe` extension, which `cmd.exe` can't execute

### Fix

**CI workflow safety net:** Before writing the batch file, the startup step now normalizes `./` to `.\` and appends `.exe` to bare compiled binary paths. This catches agent-generated Unix-style commands regardless of what the prompts say.

**Prompts and templates:** Updated all 5 scenario Go prompts, the iteration-config template, and the README to use Windows-compatible commands (`go build -o server.exe .` / `.\server.exe`). Also updated Rust examples similarly.

### Files changed (8)

| File | Change |
|------|--------|
| `.github/workflows/test-iteration.yaml` | Added Unix→Windows path normalization + `.exe` auto-append |
| `testing-v2/scenarios/*/SCENARIO.md` (5 files) | Go prompt: `server` → `server.exe`, `./` → `.\` |
| `testing-v2/scenarios/_iteration-config-template.yaml` | Go + Rust examples updated for Windows |
| `testing-v2/README.md` | Go row in language reference table updated |

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] 📝 New rule - Adding a new best practice rule
- [ ] ✏️ Rule improvement - Updating an existing rule
- [ ] 🆕 New skill - Adding an entirely new skill
- [ ] 🐛 Bug fix - Fixing an issue with existing content
- [ ] 📚 Documentation - Updating README, CONTRIBUTING, or other docs
- [x] 🔧 Build/Scripts - Changes to build process or scripts

## Checklist

<!-- Ensure you've completed these steps -->

- [ ] I have read the [Contributing Guide](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/blob/main/CONTRIBUTING.md)
- [ ] I ran `npm run validate` and it passed
- [ ] I ran `npm run build` to regenerate AGENTS.md (if adding/updating rules)
- [ ] My rule file follows the naming convention: `{prefix}-{description}.md`
- [ ] My rule includes valid frontmatter (`title`, `impact`, `tags`)

## For New Rules

<!-- Fill this out if adding a new rule, otherwise delete this section -->

**Rule file:** `skills/cosmosdb-best-practices/rules/_____.md`

**Category:** <!-- e.g., Query Optimization, Data Modeling, SDK Best Practices -->

**Impact level:** <!-- Critical / High / Medium / Low -->

**Why is this rule important?**
<!-- Explain the problem this rule addresses -->

## Testing

<!-- How did you verify this change? -->

- [ ] Tested with GitHub Copilot
- [ ] Tested with Claude Code
- [ ] Tested with Cursor
- [ ] Tested with other agent: _____
- [ ] N/A (documentation only)

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Additional Notes

<!-- Any other context or screenshots -->
