### PR TITLE
Add index-path-syntax rule for correct indexing path notation

### DIFF
--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -88,8 +88,9 @@ Performance optimization and best practices guide for Azure Cosmos DB applicatio
    - 5.2 [Use Composite Indexes for ORDER BY](#52-use-composite-indexes-for-order-by)
    - 5.3 [Exclude Unused Index Paths](#53-exclude-unused-index-paths)
    - 5.4 [Understand Indexing Modes](#54-understand-indexing-modes)
-   - 5.5 [Choose Appropriate Index Types](#55-choose-appropriate-index-types)
-   - 5.6 [Add Spatial Indexes for Geo Queries](#56-add-spatial-indexes-for-geo-queries)
+   - 5.5 [Use Correct Indexing Path Syntax](#55-use-correct-indexing-path-syntax)
+   - 5.6 [Choose Appropriate Index Types](#56-choose-appropriate-index-types)
+   - 5.7 [Add Spatial Indexes for Geo Queries](#57-add-spatial-indexes-for-geo-queries)
 6. [Throughput & Scaling](#6-throughput-scaling) — **MEDIUM**
    - 6.1 [Use Autoscale for Variable Workloads](#61-use-autoscale-for-variable-workloads)
    - 6.2 [Understand Burst Capacity](#62-understand-burst-capacity)
@@ -7695,7 +7696,90 @@ Note: Lazy mode was deprecated - use Consistent instead.
 
 Reference: [Indexing modes](https://learn.microsoft.com/azure/cosmos-db/index-policy#indexing-mode)
 
-### 5.5 Choose Appropriate Index Types
+### 5.5 Use Correct Indexing Path Syntax
+
+**Impact: HIGH** (prevents container creation failures from invalid paths)
+
+## Use Correct Indexing Path Syntax
+
+Cosmos DB indexing paths use specific notation for scalars, arrays, and wildcards. Using the wrong notation causes container creation to fail with a BadRequest error.
+
+**Three valid path notations:**
+
+| Notation | Meaning | Example |
+|----------|---------|---------|
+| `/?` | Scalar value (string or number) | `/price/?` |
+| `/[]` | Array element traversal | `/items/[]/name/?` |
+| `/*` | **Terminal** wildcard — everything below this node | `/metadata/*` |
+
+**Incorrect (using `*` for array traversal):**
+
+```json
+// ❌ WRONG — * cannot be used mid-path for array traversal
+// This causes: "The indexing path could not be accepted, failed near position ..."
+{
+    "excludedPaths": [
+        { "path": "/lineItems/*/productSnapshot/?" },
+        { "path": "/orders/*/items/?" }
+    ]
+}
+```
+
+**Correct (using `[]` for array traversal):**
+
+```json
+// ✅ CORRECT — use [] to traverse array elements
+{
+    "excludedPaths": [
+        { "path": "/lineItems/[]/productSnapshot/?" },
+        { "path": "/orders/[]/items/?" }
+    ]
+}
+```
+
+**Correct (terminal `*` wildcard for subtree):**
+
+```json
+// ✅ CORRECT — * at the END of a path matches everything below
+{
+    "includedPaths": [
+        { "path": "/*" }
+    ],
+    "excludedPaths": [
+        { "path": "/metadata/*" },
+        { "path": "/auditLog/*" },
+        { "path": "/\"_etag\"/?" }
+    ]
+}
+```
+
+**Common patterns:**
+
+```json
+{
+    "includedPaths": [
+        { "path": "/*" }
+    ],
+    "excludedPaths": [
+        { "path": "/\"_etag\"/?" },
+        { "path": "/largeBlob/*" },
+        { "path": "/items/[]/internalNotes/?" },
+        { "path": "/events/[]/payload/*" }
+    ]
+}
+```
+
+**Key rules:**
+
+- `/?` terminates a path to a scalar value — use for leaf properties
+- `/[]` traverses into array elements — use when the parent is an array and you need to reach nested properties
+- `/*` is a terminal wildcard — it means "all descendants" and must be the LAST segment in the path
+- **NEVER** use `*` in the middle of a path (e.g., `/items/*/name/?` is INVALID)
+- For composite indexes, paths do NOT use `/?` or `/*` — they have an implicit `/?` at the end. Use `/[]` for array traversal in composite paths (e.g., `/children/[]/age`)
+
+Reference: [Indexing policy path syntax](https://learn.microsoft.com/azure/cosmos-db/index-policy#include-exclude-paths)
+
+### 5.6 Choose Appropriate Index Types
 
 **Impact: MEDIUM** (optimizes query performance)
 
@@ -7824,7 +7908,7 @@ Index type summary:
 
 Reference: [Index types](https://learn.microsoft.com/azure/cosmos-db/index-overview)
 
-### 5.6 Add Spatial Indexes for Geo Queries
+### 5.7 Add Spatial Indexes for Geo Queries
 
 **Impact: MEDIUM-HIGH** (enables efficient location queries)
 

--- a/skills/cosmosdb-best-practices/SKILL.md
+++ b/skills/cosmosdb-best-practices/SKILL.md
@@ -124,6 +124,7 @@ Reference these guidelines when:
 ### 5. Indexing Strategies (MEDIUM-HIGH)
 
 - [index-exclude-unused](rules/index-exclude-unused.md) - Exclude paths never queried
+- [index-path-syntax](rules/index-path-syntax.md) - Use correct path notation (`/?`, `/[]`, `/*`)
 - [index-composite](rules/index-composite.md) - Use composite indexes for ORDER BY
 - [index-composite-direction](rules/index-composite-direction.md) - Match composite index directions to ORDER BY
 - [index-spatial](rules/index-spatial.md) - Add spatial indexes for geo queries

--- a/skills/cosmosdb-best-practices/rules/index-path-syntax.md
+++ b/skills/cosmosdb-best-practices/rules/index-path-syntax.md
@@ -1,0 +1,85 @@
+---
+title: Use Correct Indexing Path Syntax
+impact: HIGH
+impactDescription: prevents container creation failures from invalid paths
+tags: index, path, syntax, array, wildcard
+---
+
+## Use Correct Indexing Path Syntax
+
+Cosmos DB indexing paths use specific notation for scalars, arrays, and wildcards. Using the wrong notation causes container creation to fail with a BadRequest error.
+
+**Three valid path notations:**
+
+| Notation | Meaning | Example |
+|----------|---------|---------|
+| `/?` | Scalar value (string or number) | `/price/?` |
+| `/[]` | Array element traversal | `/items/[]/name/?` |
+| `/*` | **Terminal** wildcard — everything below this node | `/metadata/*` |
+
+**Incorrect (using `*` for array traversal):**
+
+```json
+// ❌ WRONG — * cannot be used mid-path for array traversal
+// This causes: "The indexing path could not be accepted, failed near position ..."
+{
+    "excludedPaths": [
+        { "path": "/lineItems/*/productSnapshot/?" },
+        { "path": "/orders/*/items/?" }
+    ]
+}
+```
+
+**Correct (using `[]` for array traversal):**
+
+```json
+// ✅ CORRECT — use [] to traverse array elements
+{
+    "excludedPaths": [
+        { "path": "/lineItems/[]/productSnapshot/?" },
+        { "path": "/orders/[]/items/?" }
+    ]
+}
+```
+
+**Correct (terminal `*` wildcard for subtree):**
+
+```json
+// ✅ CORRECT — * at the END of a path matches everything below
+{
+    "includedPaths": [
+        { "path": "/*" }
+    ],
+    "excludedPaths": [
+        { "path": "/metadata/*" },
+        { "path": "/auditLog/*" },
+        { "path": "/\"_etag\"/?" }
+    ]
+}
+```
+
+**Common patterns:**
+
+```json
+{
+    "includedPaths": [
+        { "path": "/*" }
+    ],
+    "excludedPaths": [
+        { "path": "/\"_etag\"/?" },
+        { "path": "/largeBlob/*" },
+        { "path": "/items/[]/internalNotes/?" },
+        { "path": "/events/[]/payload/*" }
+    ]
+}
+```
+
+**Key rules:**
+
+- `/?` terminates a path to a scalar value — use for leaf properties
+- `/[]` traverses into array elements — use when the parent is an array and you need to reach nested properties
+- `/*` is a terminal wildcard — it means "all descendants" and must be the LAST segment in the path
+- **NEVER** use `*` in the middle of a path (e.g., `/items/*/name/?` is INVALID)
+- For composite indexes, paths do NOT use `/?` or `/*` — they have an implicit `/?` at the end. Use `/[]` for array traversal in composite paths (e.g., `/children/[]/age`)
+
+Reference: [Indexing policy path syntax](https://learn.microsoft.com/azure/cosmos-db/index-policy#include-exclude-paths)


### PR DESCRIPTION
## Summary

Adds a new indexing rule, `index-path-syntax`, that was previously applied manually but is now missing from the repo. Its content is **not** covered by any existing index rule.

## Why

Existing index rules (`index-exclude-unused`, `index-composite`, etc.) use indexing-path notation in their examples but never explain the notation itself. Using the wrong notation — most commonly `*` mid-path for array traversal — causes container creation to fail with a `BadRequest` ("The indexing path could not be accepted, failed near position ...").

## What changed

- **New rule** `skills/cosmosdb-best-practices/rules/index-path-syntax.md` documenting:
  - `/?` — scalar leaf value
  - `/[]` — array element traversal
  - `/*` — terminal wildcard (must be the last segment)
  - The common mistake of using `*` mid-path, with correct/incorrect examples and a docs reference.
- **Registered** the rule in `skills/cosmosdb-best-practices/SKILL.md` Quick Reference (section 5, Indexing Strategies).
- **Rebuilt** `skills/cosmosdb-best-practices/AGENTS.md` via `npm run build` — now 106 rules; the new rule appears as §5.5.

## Validation

- `npm run build` ✓ (compiled 106 rules)
- `npm run validate` ✓ for the new file. (Pre-existing validation errors in unrelated files were left untouched.)