### PR TITLE
feat: add rule for TTL-based automatic data expiration

### DIFF
--- a/evals/cosmosdb-best-practices/tasks/model-ttl-expiration.yaml
+++ b/evals/cosmosdb-best-practices/tasks/model-ttl-expiration.yaml
@@ -1,0 +1,18 @@
+id: model-ttl-expiration
+name: Data Modeling - TTL for Automatic Data Expiration
+description: |
+  Test that the skill recommends container TTL with per-item overrides
+  instead of a scheduled cleanup job for expiring old data.
+tags:
+  - modeling
+  - happy-path
+  - ttl
+inputs:
+  prompt: |
+    My app stores user session documents in a Cosmos DB container. Sessions
+    should be deleted 24 hours after the last activity. I was going to write
+    an Azure Function on a timer that queries for old sessions and deletes
+    them in a loop. Is there a better way to handle this?
+expected:
+  outcomes:
+    - type: task_completed

--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -1322,8 +1322,6 @@ Reference: [Schema evolution in Cosmos DB](https://learn.microsoft.com/azure/cos
 
 **Impact: MEDIUM** (expired data is removed automatically in the background instead of through costly cleanup jobs)
 
-## Use TTL for Automatic Data Expiration
-
 Cosmos DB can delete expired items for you. Enable Time-to-Live on the container and items past their expiry are removed by a background process that uses leftover request units, so you pay nothing extra in RUs and write no cleanup code. Scheduled cleanup jobs that query for old items and delete them one by one burn RUs on every run and compete with your live traffic.
 
 The most flexible setup is a container default of `-1` (items never expire on their own) combined with a per-item `ttl` property in seconds. Items that set `ttl` expire on their own schedule, items that omit it stick around forever. You can also set a positive container default so everything expires unless an item overrides it.

--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -29,7 +29,8 @@ Performance optimization and best practices guide for Azure Cosmos DB applicatio
    - 1.8 [Reference Data When Items Grow Large](#18-reference-data-when-items-grow-large)
    - 1.9 [Use ID references with transient hydration for document relationships](#19-use-id-references-with-transient-hydration-for-document-relationships)
    - 1.10 [Version Your Document Schemas](#110-version-your-document-schemas)
-   - 1.11 [Use Type Discriminators for Polymorphic Data](#111-use-type-discriminators-for-polymorphic-data)
+   - 1.11 [Use TTL for Automatic Data Expiration](#111-use-ttl-for-automatic-data-expiration)
+   - 1.12 [Use Type Discriminators for Polymorphic Data](#112-use-type-discriminators-for-polymorphic-data)
 2. [Partition Key Design](#2-partition-key-design) — **CRITICAL**
    - 2.1 [Plan for 20GB Logical Partition Limit](#21-plan-for-20gb-logical-partition-limit)
    - 2.2 [Distribute Writes to Avoid Hot Partitions](#22-distribute-writes-to-avoid-hot-partitions)
@@ -1317,7 +1318,88 @@ Always increment version when:
 
 Reference: [Schema evolution in Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/modeling-data)
 
-### 1.11 Use Type Discriminators for Polymorphic Data
+### 1.11 Use TTL for Automatic Data Expiration
+
+**Impact: MEDIUM** (expired data is removed automatically in the background instead of through costly cleanup jobs)
+
+## Use TTL for Automatic Data Expiration
+
+Cosmos DB can delete expired items for you. Enable Time-to-Live on the container and items past their expiry are removed by a background process that uses leftover request units, so you pay nothing extra in RUs and write no cleanup code. Scheduled cleanup jobs that query for old items and delete them one by one burn RUs on every run and compete with your live traffic.
+
+The most flexible setup is a container default of `-1` (items never expire on their own) combined with a per-item `ttl` property in seconds. Items that set `ttl` expire on their own schedule, items that omit it stick around forever. You can also set a positive container default so everything expires unless an item overrides it.
+
+Typical fits: session tokens, event logs, temporary caches, OTP codes, telemetry with a fixed retention window.
+
+**Incorrect (scheduled cleanup job):**
+
+```csharp
+// Timer-triggered job that scans for expired sessions and deletes them
+public async Task CleanupExpiredSessions()
+{
+    var cutoff = DateTimeOffset.UtcNow.AddHours(-24).ToUnixTimeSeconds();
+    var query = new QueryDefinition(
+        "SELECT c.id, c.userId FROM c WHERE c._ts < @cutoff")
+        .WithParameter("@cutoff", cutoff);
+
+    // Cross-partition query plus a delete per item, every single run
+    using var iterator = container.GetItemQueryIterator<SessionRef>(query);
+    while (iterator.HasMoreResults)
+    {
+        foreach (var session in await iterator.ReadNextAsync())
+        {
+            await container.DeleteItemAsync<SessionRef>(
+                session.Id, new PartitionKey(session.UserId));
+        }
+    }
+}
+```
+
+**Correct (TTL on the container, per-item overrides):**
+
+```csharp
+// Enable TTL with no default expiry; items opt in via their ttl property
+var properties = new ContainerProperties("sessions", "/userId")
+{
+    DefaultTimeToLive = -1
+};
+await database.CreateContainerIfNotExistsAsync(properties);
+
+public class Session
+{
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    [JsonProperty("userId")]
+    public string UserId { get; set; }
+
+    // Expires 24 hours after the last write to this item
+    [JsonProperty("ttl")]
+    public int Ttl { get; set; } = 86400;
+}
+
+public class AuditRecord
+{
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    [JsonProperty("userId")]
+    public string UserId { get; set; }
+
+    // No ttl property: with a -1 container default this never expires
+}
+```
+
+The expiry clock is based on `_ts`, the item's last modified time, so any update resets it. That is handy for sliding expirations like sessions, but if you need a fixed retention window, avoid touching items you expect to age out, or store an absolute expiry date and compute `ttl` from it at write time.
+
+A few things to know:
+
+- TTL on an item does nothing unless TTL is enabled on the container. With `DefaultTimeToLive` unset, per-item `ttl` values are ignored.
+- Deletion is not instant. Expired items are removed when spare RUs are available, but they stop appearing in query results as soon as they expire.
+- Setting `ttl` to `-1` on an item makes that item never expire, even when the container has a positive default.
+
+Reference: [Time to Live in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)
+
+### 1.12 Use Type Discriminators for Polymorphic Data
 
 **Impact: MEDIUM** (enables efficient single-container design)
 

--- a/skills/cosmosdb-best-practices/rules/model-ttl-expiration.md
+++ b/skills/cosmosdb-best-practices/rules/model-ttl-expiration.md
@@ -5,8 +5,6 @@ impactDescription: expired data is removed automatically in the background inste
 tags: model, ttl, expiration, retention, cleanup
 ---
 
-## Use TTL for Automatic Data Expiration
-
 Cosmos DB can delete expired items for you. Enable Time-to-Live on the container and items past their expiry are removed by a background process that uses leftover request units, so you pay nothing extra in RUs and write no cleanup code. Scheduled cleanup jobs that query for old items and delete them one by one burn RUs on every run and compete with your live traffic.
 
 The most flexible setup is a container default of `-1` (items never expire on their own) combined with a per-item `ttl` property in seconds. Items that set `ttl` expire on their own schedule, items that omit it stick around forever. You can also set a positive container default so everything expires unless an item overrides it.

--- a/skills/cosmosdb-best-practices/rules/model-ttl-expiration.md
+++ b/skills/cosmosdb-best-practices/rules/model-ttl-expiration.md
@@ -1,0 +1,83 @@
+---
+title: Use TTL for Automatic Data Expiration
+impact: MEDIUM
+impactDescription: expired data is removed automatically in the background instead of through costly cleanup jobs
+tags: model, ttl, expiration, retention, cleanup
+---
+
+## Use TTL for Automatic Data Expiration
+
+Cosmos DB can delete expired items for you. Enable Time-to-Live on the container and items past their expiry are removed by a background process that uses leftover request units, so you pay nothing extra in RUs and write no cleanup code. Scheduled cleanup jobs that query for old items and delete them one by one burn RUs on every run and compete with your live traffic.
+
+The most flexible setup is a container default of `-1` (items never expire on their own) combined with a per-item `ttl` property in seconds. Items that set `ttl` expire on their own schedule, items that omit it stick around forever. You can also set a positive container default so everything expires unless an item overrides it.
+
+Typical fits: session tokens, event logs, temporary caches, OTP codes, telemetry with a fixed retention window.
+
+**Incorrect (scheduled cleanup job):**
+
+```csharp
+// Timer-triggered job that scans for expired sessions and deletes them
+public async Task CleanupExpiredSessions()
+{
+    var cutoff = DateTimeOffset.UtcNow.AddHours(-24).ToUnixTimeSeconds();
+    var query = new QueryDefinition(
+        "SELECT c.id, c.userId FROM c WHERE c._ts < @cutoff")
+        .WithParameter("@cutoff", cutoff);
+
+    // Cross-partition query plus a delete per item, every single run
+    using var iterator = container.GetItemQueryIterator<SessionRef>(query);
+    while (iterator.HasMoreResults)
+    {
+        foreach (var session in await iterator.ReadNextAsync())
+        {
+            await container.DeleteItemAsync<SessionRef>(
+                session.Id, new PartitionKey(session.UserId));
+        }
+    }
+}
+```
+
+**Correct (TTL on the container, per-item overrides):**
+
+```csharp
+// Enable TTL with no default expiry; items opt in via their ttl property
+var properties = new ContainerProperties("sessions", "/userId")
+{
+    DefaultTimeToLive = -1
+};
+await database.CreateContainerIfNotExistsAsync(properties);
+
+public class Session
+{
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    [JsonProperty("userId")]
+    public string UserId { get; set; }
+
+    // Expires 24 hours after the last write to this item
+    [JsonProperty("ttl")]
+    public int Ttl { get; set; } = 86400;
+}
+
+public class AuditRecord
+{
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    [JsonProperty("userId")]
+    public string UserId { get; set; }
+
+    // No ttl property: with a -1 container default this never expires
+}
+```
+
+The expiry clock is based on `_ts`, the item's last modified time, so any update resets it. That is handy for sliding expirations like sessions, but if you need a fixed retention window, avoid touching items you expect to age out, or store an absolute expiry date and compute `ttl` from it at write time.
+
+A few things to know:
+
+- TTL on an item does nothing unless TTL is enabled on the container. With `DefaultTimeToLive` unset, per-item `ttl` values are ignored.
+- Deletion is not instant. Expired items are removed when spare RUs are available, but they stop appearing in query results as soon as they expire.
+- Setting `ttl` to `-1` on an item makes that item never expire, even when the container has a positive default.
+
+Reference: [Time to Live in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)


### PR DESCRIPTION
## Description

Adds a Data Modeling rule about using TTL for automatic data expiration instead of scheduled cleanup jobs. A lot of apps run timer
-triggered functions that query for old items and delete them in a loop, which burns RUs on every run. The rule shows enabling TTL on the container with a -1 default and per-item ttl overrides, covers the common fits (sessions, event logs, temp caches), and the gotchas: expiry rides on _ts so updates reset the clock, deletes are lazy but expired items drop out of queries right away, and per-item ttl does nothing if container TTL is off. Comes with an eval task.

## Type of Change

- [x] 📝 New rule - Adding a new best practice rule
- [ ] ✏️ Rule improvement - Updating an existing rule
- [ ] 🆕 New skill - Adding an entirely new skill
- [ ] 🐛 Bug fix - Fixing an issue with existing content
- [ ] 📚 Documentation - Updating README, CONTRIBUTING, or other docs
- [ ] 🔧 Build/Scripts - Changes to build process or scripts

## Checklist

- [x] I have read the [Contributing Guide](https:/mosdb-agent-kit/blob/main/CONTRIBUTING.md)
- [x] I ran `npm run validate` and it passed
- [x] I ran `npm run build` to regenerate AGENTS.m
- [x] My rule file follows the naming convention: `{prefix}-{description}.md`
- [x] My rule includes valid frontmatter (`title`,

## Tests (Required)

- [x] I added/updated an eval task in `evals/cosmo
- [x] I ran `waza run evals/cosmosdb-best-practices/eval.yaml` and all tasks pass
- [x] My task file includes `id`, `name`, `descripexpected.outcomes`

**Eval task file:** `evals/cosmosdb-best-practicesaml`

## For New Rules

**Rule file:** `skills/cosmosdb-best-practices/rul

**Category:** Data Modeling

**Impact level:** Medium

**Why is this rule important?**
TTL is built into Cosmos DB and the deletes run in the background on leftover request units, yet people keep writing cleanup jobs that do cross-partition queries plus a delete per s RUs, competes with live traffic, and is extra code to maintain. Agents should reach for container TTL with per-item overrides first and know the _ts reset behavior so sliding vs fixed expirations come out right.

## Agent Testing

- [ ] Tested with GitHub Copilot
- [x] Tested with Claude Code
- [ ] Tested with Cursor
- [ ] Tested with other agent: _____
- [ ] N/A (documentation only)

## Related Issues

Closes #166