### PR TITLE
feat(rule): clarify Cosmos DB id is always a string

### DIFF
--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -1,6 +1,6 @@
 # Azure Cosmos DB Best Practices
 
-**Version 1.0.0**  
+**Version 1.1.0**  
 CosmosDB Agent Kit  
 January 2026
 
@@ -590,6 +590,63 @@ This is a cross-SDK issue affecting any SDK using Gateway mode. The Python SDK u
 | Any non-ASCII | Encoded differently across clients; known issues in ADF / Spark / Kafka connectors |
 
 **Safe synthetic-id separators:** `_`, `-`, `:`
+
+### The `id` property is always a string
+
+Azure Cosmos DB stores and indexes the `id` system property as a JSON string. There is no numeric `id` type.
+
+When migrating from a relational database, keep the primary-key value but store it as a string `id` value:
+
+| Relational key | Cosmos DB `id` |
+|---------------|---------------|
+| `42` | `"42"` |
+| `90001` | `"90001"` |
+
+Bind `id` to a string type in DTOs, domain models, and API contracts.
+
+**Incorrect:**
+
+```csharp
+public record Product(int Id, string Name);
+```
+
+**Correct:**
+
+```csharp
+public record Product(string Id, string Name);
+```
+
+### SQL to NoSQL migration guidance
+
+Do not introduce a parallel numeric copy of `id` solely for sorting or pagination.
+
+**Incorrect:**
+
+```sql
+SELECT * FROM c
+ORDER BY c.idNum
+```
+
+**Correct (for string ordering by id):**
+
+```sql
+SELECT * FROM c
+ORDER BY c.id
+```
+
+If numeric ordering is required, use a dedicated business field such as `sku`, `sequenceNumber`, or another domain-specific numeric property:
+
+```sql
+SELECT * FROM c
+ORDER BY c.sequenceNumber
+```
+
+Do not introduce a numeric shadow copy of `id` solely for sorting or pagination.
+
+| Symptom | Cause |
+|----------|--------|
+| Could not convert `$.id` to `Int32` | DTO binds `id` to a numeric type |
+| Unexpected pagination ordering | Sorting by a numeric shadow id instead of `c.id` |
 
 **Incorrect (oversized or problematic IDs):**
 

--- a/skills/cosmosdb-best-practices/rules/model-id-constraints.md
+++ b/skills/cosmosdb-best-practices/rules/model-id-constraints.md
@@ -35,6 +35,56 @@ This is a cross-SDK issue affecting any SDK using Gateway mode. The Python SDK u
 
 **Safe synthetic-id separators:** `_`, `-`, `:`
 
+### The `id` property is always a string
+
+Azure Cosmos DB stores and indexes the `id` system property as a JSON string. There is no numeric `id` type.
+
+When migrating from a relational database, keep the primary-key value but store it as a string `id` value:
+
+| Relational key | Cosmos DB `id` |
+|---------------|---------------|
+| `42` | `"42"` |
+| `90001` | `"90001"` |
+
+Bind `id` to a string type in DTOs, domain models, and API contracts.
+
+**Incorrect:**
+
+```csharp
+public record Product(int Id, string Name);
+```
+
+**Correct:**
+
+```csharp
+public record Product(string Id, string Name);
+```
+
+### SQL to NoSQL migration guidance
+
+Do not introduce a parallel numeric copy of `id` solely for sorting or pagination.
+
+**Incorrect:**
+
+```sql
+SELECT * FROM c
+ORDER BY c.idNum
+```
+
+**Correct:**
+
+```sql
+SELECT * FROM c
+ORDER BY c.id
+```
+
+If numeric ordering is required, use a dedicated business field such as `sku`, `sequenceNumber`, or another domain-specific numeric property instead of a shadow copy of `id`.
+
+| Symptom | Cause |
+|----------|--------|
+| Could not convert `$.id` to `Int32` | DTO binds `id` to a numeric type |
+| Unexpected pagination ordering | Sorting by a numeric shadow id instead of `c.id` |
+
 **Incorrect (oversized or problematic IDs):**
 
 ```csharp

--- a/skills/cosmosdb-best-practices/rules/model-id-constraints.md
+++ b/skills/cosmosdb-best-practices/rules/model-id-constraints.md
@@ -71,14 +71,21 @@ SELECT * FROM c
 ORDER BY c.idNum
 ```
 
-**Correct:**
+**Correct (for string ordering by id):**
 
 ```sql
 SELECT * FROM c
 ORDER BY c.id
 ```
 
-If numeric ordering is required, use a dedicated business field such as `sku`, `sequenceNumber`, or another domain-specific numeric property instead of a shadow copy of `id`.
+If numeric ordering is required, use a dedicated business field such as `sku`, `sequenceNumber`, or another domain-specific numeric property:
+
+```sql
+SELECT * FROM c
+ORDER BY c.sequenceNumber
+```
+
+Do not introduce a numeric shadow copy of `id` solely for sorting or pagination.
 
 | Symptom | Cause |
 |----------|--------|

--- a/skills/cosmosdb-data-modeling/AGENTS.md
+++ b/skills/cosmosdb-data-modeling/AGENTS.md
@@ -477,6 +477,63 @@ This is a cross-SDK issue affecting any SDK using Gateway mode. The Python SDK u
 
 **Safe synthetic-id separators:** `_`, `-`, `:`
 
+### The `id` property is always a string
+
+Azure Cosmos DB stores and indexes the `id` system property as a JSON string. There is no numeric `id` type.
+
+When migrating from a relational database, keep the primary-key value but store it as a string `id` value:
+
+| Relational key | Cosmos DB `id` |
+|---------------|---------------|
+| `42` | `"42"` |
+| `90001` | `"90001"` |
+
+Bind `id` to a string type in DTOs, domain models, and API contracts.
+
+**Incorrect:**
+
+```csharp
+public record Product(int Id, string Name);
+```
+
+**Correct:**
+
+```csharp
+public record Product(string Id, string Name);
+```
+
+### SQL to NoSQL migration guidance
+
+Do not introduce a parallel numeric copy of `id` solely for sorting or pagination.
+
+**Incorrect:**
+
+```sql
+SELECT * FROM c
+ORDER BY c.idNum
+```
+
+**Correct (for string ordering by id):**
+
+```sql
+SELECT * FROM c
+ORDER BY c.id
+```
+
+If numeric ordering is required, use a dedicated business field such as `sku`, `sequenceNumber`, or another domain-specific numeric property:
+
+```sql
+SELECT * FROM c
+ORDER BY c.sequenceNumber
+```
+
+Do not introduce a numeric shadow copy of `id` solely for sorting or pagination.
+
+| Symptom | Cause |
+|----------|--------|
+| Could not convert `$.id` to `Int32` | DTO binds `id` to a numeric type |
+| Unexpected pagination ordering | Sorting by a numeric shadow id instead of `c.id` |
+
 **Incorrect (oversized or problematic IDs):**
 
 ```csharp

--- a/skills/cosmosdb-data-modeling/rules/model-id-constraints.md
+++ b/skills/cosmosdb-data-modeling/rules/model-id-constraints.md
@@ -35,6 +35,56 @@ This is a cross-SDK issue affecting any SDK using Gateway mode. The Python SDK u
 
 **Safe synthetic-id separators:** `_`, `-`, `:`
 
+### The `id` property is always a string
+
+Azure Cosmos DB stores and indexes the `id` system property as a JSON string. There is no numeric `id` type.
+
+When migrating from a relational database, keep the primary-key value but store it as a string `id` value:
+
+| Relational key | Cosmos DB `id` |
+|---------------|---------------|
+| `42` | `"42"` |
+| `90001` | `"90001"` |
+
+Bind `id` to a string type in DTOs, domain models, and API contracts.
+
+**Incorrect:**
+
+```csharp
+public record Product(int Id, string Name);
+```
+
+**Correct:**
+
+```csharp
+public record Product(string Id, string Name);
+```
+
+### SQL to NoSQL migration guidance
+
+Do not introduce a parallel numeric copy of `id` solely for sorting or pagination.
+
+**Incorrect:**
+
+```sql
+SELECT * FROM c
+ORDER BY c.idNum
+```
+
+**Correct:**
+
+```sql
+SELECT * FROM c
+ORDER BY c.id
+```
+
+If numeric ordering is required, use a dedicated business field such as `sku`, `sequenceNumber`, or another domain-specific numeric property instead of a shadow copy of `id`.
+
+| Symptom | Cause |
+|----------|--------|
+| Could not convert `$.id` to `Int32` | DTO binds `id` to a numeric type |
+| Unexpected pagination ordering | Sorting by a numeric shadow id instead of `c.id` |
+
 **Incorrect (oversized or problematic IDs):**
 
 ```csharp

--- a/skills/cosmosdb-data-modeling/rules/model-id-constraints.md
+++ b/skills/cosmosdb-data-modeling/rules/model-id-constraints.md
@@ -71,14 +71,21 @@ SELECT * FROM c
 ORDER BY c.idNum
 ```
 
-**Correct:**
+**Correct (for string ordering by id):**
 
 ```sql
 SELECT * FROM c
 ORDER BY c.id
 ```
 
-If numeric ordering is required, use a dedicated business field such as `sku`, `sequenceNumber`, or another domain-specific numeric property instead of a shadow copy of `id`.
+If numeric ordering is required, use a dedicated business field such as `sku`, `sequenceNumber`, or another domain-specific numeric property:
+
+```sql
+SELECT * FROM c
+ORDER BY c.sequenceNumber
+```
+
+Do not introduce a numeric shadow copy of `id` solely for sorting or pagination.
 
 | Symptom | Cause |
 |----------|--------|


### PR DESCRIPTION
## Description

Adds guidance to the existing `model-id-constraints` rule clarifying that the Azure Cosmos DB `id` system property is always a JSON string and should not be modeled as a numeric type.

The update also adds SQL-to-NoSQL migration guidance, DTO examples, sorting recommendations, and a symptom table covering common issues caused by numeric `id` modeling.

## Type of Change

* [ ] 📝 New rule - Adding a new best practice rule
* [x] ✏️ Rule improvement - Updating an existing rule
* [ ] 🆕 New skill - Adding an entirely new skill
* [ ] 🐛 Bug fix - Fixing an issue with existing content
* [ ] 📚 Documentation - Updating README, CONTRIBUTING, or other docs
* [ ] 🔧 Build/Scripts - Changes to build process or scripts

## Checklist

* [x] I have read the Contributing Guide
* [ ] I ran `npm run validate` and it passed
* [ ] I ran `npm run build` to regenerate AGENTS.md (if adding/updating rules)
* [x] My rule file follows the naming convention: `{prefix}-{description}.md`
* [x] My rule includes valid frontmatter (`title`, `impact`, `tags`)

## Agent Testing

* [ ] Tested with GitHub Copilot
* [ ] Tested with Claude Code
* [ ] Tested with Cursor
* [ ] Tested with other agent: _____
* [x] N/A (documentation/rule update only)

## Related Issues

Fixes #199

## Additional Notes

Updated the following files:

* `skills/cosmosdb-best-practices/rules/model-id-constraints.md`
* `skills/cosmosdb-data-modeling/rules/model-id-constraints.md`

Added:

* Guidance that `id` is always a JSON string.
* Relational integer primary key migration examples.
* Correct and incorrect DTO modeling examples.
* Guidance against using numeric shadow IDs for sorting and pagination.
* A symptom table describing common failures caused by numeric `id` modeling.
