### PR TITLE
Tighten sdk-diagnostics: mandate .Diagnostics capture in CosmosException catch blocks (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This is the high-level log. For detailed per-iteration evaluation notes (test re
 
 ---
 
+## 2026-06-18 — `sdk-diagnostics`: enforce `.Diagnostics` capture in `CosmosException` catch blocks ([#156](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/issues/156))
+
+- **Amended:** `sdk-diagnostics.md` — Rewrote the acceptance criterion as a strict syntactic minimum: every `catch` declaring `CosmosException` (or a subclass) must reference `.Diagnostics` on the caught variable inside the block. Added three violation patterns (log-message-only, diagnostics-dropping re-wrap, bare swallow), a minimal acceptable catch block (`StatusCode`/`ActivityId`/`RequestCharge`/`Diagnostics`), a diagnostics-preserving re-wrap variant, a mechanical detector description (Roslyn/regex), "Why it matters" cross-links to the throughput/RU and 429/retry rules, and a deep-linked reference (`#capture-diagnostics`). Addresses the 0/38 adoption baseline reported in the issue.
+- **Dual-skill update:** Applied identically to the monolith `cosmosdb-best-practices` skill and the split `cosmosdb-sdk` skill; regenerated both compiled `AGENTS.md` files.
+
 ## 2026-06-15 — `sdk-go-partition-key-metadata`: Go cross-SDK partition metadata guidance ([#161](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/issues/161))
 
 - **New rule:** `sdk-go-partition-key-metadata.md` — Instructs agents to avoid stale `azcosmos` pins, prefer current Go SDK releases, and create single-path partition keys with explicit metadata that interoperates with other Cosmos DB SDKs used by verifiers.

--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -4267,9 +4267,9 @@ Reference: [Query with continuation tokens (Java SDK)](https://learn.microsoft.c
 
 Capture and log diagnostics from Cosmos DB responses, especially for slow or failed operations. Diagnostics contain crucial information for troubleshooting.
 
-`CosmosException.Diagnostics` (type `CosmosDiagnostics`) is the only first-class structured signal the SDK provides for debugging RU spend, latency tails, 429s, region selection, and channel reuse. Demonstrating the pattern is not enough — it must be applied at the point of failure.
+`CosmosException.Diagnostics` (type `CosmosDiagnostics`) is a first-class structured signal the SDK provides for debugging failures (RU spend, latency tails, 429s, region selection, and channel reuse). Demonstrating the pattern is not enough — it must be applied at the point of failure.
 
-**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass such as `CosmosOperationCanceledException`) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation regardless of the block body.
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
 
 **Incorrect (ignoring diagnostics):**
 
@@ -4298,7 +4298,7 @@ catch (CosmosException ex)
     throw;
 }
 
-// Pattern B — re-wrap, lose Diagnostics entirely (VIOLATION)
+// Pattern B — re-wrap without surfacing Diagnostics (VIOLATION)
 catch (CosmosException ex)
 {
     throw new InvalidOperationException($"Cosmos error: {ex.StatusCode}", ex);

--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -4267,6 +4267,10 @@ Reference: [Query with continuation tokens (Java SDK)](https://learn.microsoft.c
 
 Capture and log diagnostics from Cosmos DB responses, especially for slow or failed operations. Diagnostics contain crucial information for troubleshooting.
 
+`CosmosException.Diagnostics` (type `CosmosDiagnostics`) is the only first-class structured signal the SDK provides for debugging RU spend, latency tails, 429s, region selection, and channel reuse. Demonstrating the pattern is not enough — it must be applied at the point of failure.
+
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass such as `CosmosOperationCanceledException`) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation regardless of the block body.
+
 **Incorrect (ignoring diagnostics):**
 
 ```csharp
@@ -4283,6 +4287,27 @@ public async Task<Order> GetOrder(string orderId, string customerId)
         _logger.LogError("Failed to read order: {Message}", ex.Message);
         throw;
     }
+}
+```
+
+```csharp
+// Pattern A — log message text only, drop Diagnostics (VIOLATION)
+catch (CosmosException ex)
+{
+    _logger.LogError(ex, "Cosmos call failed: {Message}", ex.Message);
+    throw;
+}
+
+// Pattern B — re-wrap, lose Diagnostics entirely (VIOLATION)
+catch (CosmosException ex)
+{
+    throw new InvalidOperationException($"Cosmos error: {ex.StatusCode}", ex);
+}
+
+// Pattern C — bare swallow (VIOLATION)
+catch (CosmosException)
+{
+    return null;
 }
 ```
 
@@ -4370,6 +4395,29 @@ _logger.LogInformation(
 // IndexMetrics shows which indexes were used/not used
 ```
 
+Minimal acceptable catch block — `ex.Diagnostics` is the non-negotiable part. `StatusCode`, `ActivityId`, and `RequestCharge` are strongly recommended (`CosmosDiagnostics.ToString()` includes the latter two, but having them as structured fields makes log search trivial):
+
+```csharp
+catch (CosmosException ex)
+{
+    _logger.LogError(ex,
+        "Cosmos call failed. StatusCode={Status} ActivityId={ActivityId} " +
+        "RequestCharge={RU} Diagnostics={Diagnostics}",
+        ex.StatusCode, ex.ActivityId, ex.RequestCharge, ex.Diagnostics);
+    throw;
+}
+```
+
+If you must re-wrap, carry the diagnostics forward so they are not lost:
+
+```csharp
+catch (CosmosException ex)
+{
+    throw new InvalidOperationException(
+        $"Cosmos error: {ex.StatusCode}. Diagnostics={ex.Diagnostics}", ex);
+}
+```
+
 Key diagnostic fields:
 - `GetClientElapsedTime()`: Total client-side time
 - `RequestCharge`: RU consumed
@@ -4377,7 +4425,11 @@ Key diagnostic fields:
 - Retry information
 - Connection information
 
-Reference: [Capture diagnostics](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk)
+**Detector (mechanical check):** For each `catch` clause whose declared type binds to `Microsoft.Azure.Cosmos.CosmosException` (or a subclass), verify the block body contains a member access ending in `.Diagnostics` on the caught variable. If absent, flag the catch-block source range. This is expressible as a Roslyn analyzer or a regex over `.cs` files (excluding `bin/`, `obj/`, and test directories).
+
+**Why it matters:** `Diagnostics` carries the RU charge, activity ID, the region the call hit, and the per-channel timing breakdown. On a 429 it also contains the back-end retry hints. Without it, the operator loses exactly the information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
+
+Reference: [Capture diagnostics — Troubleshoot .NET SDK](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk#capture-diagnostics)
 
 ### 4.8 Use Microsoft.Azure.Cosmos package, not abandoned Azure.Cosmos
 

--- a/skills/cosmosdb-best-practices/rules/sdk-diagnostics.md
+++ b/skills/cosmosdb-best-practices/rules/sdk-diagnostics.md
@@ -9,6 +9,10 @@ tags: sdk, diagnostics, logging, monitoring
 
 Capture and log diagnostics from Cosmos DB responses, especially for slow or failed operations. Diagnostics contain crucial information for troubleshooting.
 
+`CosmosException.Diagnostics` (type `CosmosDiagnostics`) is the only first-class structured signal the SDK provides for debugging RU spend, latency tails, 429s, region selection, and channel reuse. Demonstrating the pattern is not enough — it must be applied at the point of failure.
+
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass such as `CosmosOperationCanceledException`) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation regardless of the block body.
+
 **Incorrect (ignoring diagnostics):**
 
 ```csharp
@@ -25,6 +29,27 @@ public async Task<Order> GetOrder(string orderId, string customerId)
         _logger.LogError("Failed to read order: {Message}", ex.Message);
         throw;
     }
+}
+```
+
+```csharp
+// Pattern A — log message text only, drop Diagnostics (VIOLATION)
+catch (CosmosException ex)
+{
+    _logger.LogError(ex, "Cosmos call failed: {Message}", ex.Message);
+    throw;
+}
+
+// Pattern B — re-wrap, lose Diagnostics entirely (VIOLATION)
+catch (CosmosException ex)
+{
+    throw new InvalidOperationException($"Cosmos error: {ex.StatusCode}", ex);
+}
+
+// Pattern C — bare swallow (VIOLATION)
+catch (CosmosException)
+{
+    return null;
 }
 ```
 
@@ -112,6 +137,29 @@ _logger.LogInformation(
 // IndexMetrics shows which indexes were used/not used
 ```
 
+Minimal acceptable catch block — `ex.Diagnostics` is the non-negotiable part. `StatusCode`, `ActivityId`, and `RequestCharge` are strongly recommended (`CosmosDiagnostics.ToString()` includes the latter two, but having them as structured fields makes log search trivial):
+
+```csharp
+catch (CosmosException ex)
+{
+    _logger.LogError(ex,
+        "Cosmos call failed. StatusCode={Status} ActivityId={ActivityId} " +
+        "RequestCharge={RU} Diagnostics={Diagnostics}",
+        ex.StatusCode, ex.ActivityId, ex.RequestCharge, ex.Diagnostics);
+    throw;
+}
+```
+
+If you must re-wrap, carry the diagnostics forward so they are not lost:
+
+```csharp
+catch (CosmosException ex)
+{
+    throw new InvalidOperationException(
+        $"Cosmos error: {ex.StatusCode}. Diagnostics={ex.Diagnostics}", ex);
+}
+```
+
 Key diagnostic fields:
 - `GetClientElapsedTime()`: Total client-side time
 - `RequestCharge`: RU consumed
@@ -119,4 +167,8 @@ Key diagnostic fields:
 - Retry information
 - Connection information
 
-Reference: [Capture diagnostics](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk)
+**Detector (mechanical check):** For each `catch` clause whose declared type binds to `Microsoft.Azure.Cosmos.CosmosException` (or a subclass), verify the block body contains a member access ending in `.Diagnostics` on the caught variable. If absent, flag the catch-block source range. This is expressible as a Roslyn analyzer or a regex over `.cs` files (excluding `bin/`, `obj/`, and test directories).
+
+**Why it matters:** `Diagnostics` carries the RU charge, activity ID, the region the call hit, and the per-channel timing breakdown. On a 429 it also contains the back-end retry hints. Without it, the operator loses exactly the information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
+
+Reference: [Capture diagnostics — Troubleshoot .NET SDK](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk#capture-diagnostics)

--- a/skills/cosmosdb-best-practices/rules/sdk-diagnostics.md
+++ b/skills/cosmosdb-best-practices/rules/sdk-diagnostics.md
@@ -11,7 +11,7 @@ Capture and log diagnostics from Cosmos DB responses, especially for slow or fai
 
 `CosmosException.Diagnostics` (type `CosmosDiagnostics`) is the only first-class structured signal the SDK provides for debugging RU spend, latency tails, 429s, region selection, and channel reuse. Demonstrating the pattern is not enough — it must be applied at the point of failure.
 
-**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass such as `CosmosOperationCanceledException`) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation regardless of the block body.
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass such as `CosmosOperationCanceledException`) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A catch block that swallows the exception (e.g., `catch (CosmosException) { }`, or returning `null` / `default` / `new T()`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
 
 **Incorrect (ignoring diagnostics):**
 
@@ -169,6 +169,6 @@ Key diagnostic fields:
 
 **Detector (mechanical check):** For each `catch` clause whose declared type binds to `Microsoft.Azure.Cosmos.CosmosException` (or a subclass), verify the block body contains a member access ending in `.Diagnostics` on the caught variable. If absent, flag the catch-block source range. This is expressible as a Roslyn analyzer or a regex over `.cs` files (excluding `bin/`, `obj/`, and test directories).
 
-**Why it matters:** `Diagnostics` carries the RU charge, activity ID, the region the call hit, and the per-channel timing breakdown. On a 429 it also contains the back-end retry hints. Without it, the operator loses exactly the information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
+**Why it matters:** `RequestCharge` and `ActivityId` provide immediate cost/correlation context, and `Diagnostics` provides the detailed timeline, regions contacted, and retry/transient-failure context (on a 429 it also includes retry details). Without diagnostics, the operator loses the detailed information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
 
 Reference: [Capture diagnostics — Troubleshoot .NET SDK](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk#capture-diagnostics)

--- a/skills/cosmosdb-best-practices/rules/sdk-diagnostics.md
+++ b/skills/cosmosdb-best-practices/rules/sdk-diagnostics.md
@@ -9,9 +9,9 @@ tags: sdk, diagnostics, logging, monitoring
 
 Capture and log diagnostics from Cosmos DB responses, especially for slow or failed operations. Diagnostics contain crucial information for troubleshooting.
 
-`CosmosException.Diagnostics` (type `CosmosDiagnostics`) is the only first-class structured signal the SDK provides for debugging RU spend, latency tails, 429s, region selection, and channel reuse. Demonstrating the pattern is not enough — it must be applied at the point of failure.
+`CosmosException.Diagnostics` (type `CosmosDiagnostics`) is a first-class structured signal the SDK provides for debugging failures (RU spend, latency tails, 429s, region selection, and channel reuse). Demonstrating the pattern is not enough — it must be applied at the point of failure.
 
-**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass such as `CosmosOperationCanceledException`) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A catch block that swallows the exception (e.g., `catch (CosmosException) { }`, or returning `null` / `default` / `new T()`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A catch block that swallows the exception (e.g., `catch (CosmosException) { }`, or returning `null` / `default` / `new T()`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
 
 **Incorrect (ignoring diagnostics):**
 
@@ -40,7 +40,7 @@ catch (CosmosException ex)
     throw;
 }
 
-// Pattern B — re-wrap, lose Diagnostics entirely (VIOLATION)
+// Pattern B — re-wrap without surfacing Diagnostics (VIOLATION)
 catch (CosmosException ex)
 {
     throw new InvalidOperationException($"Cosmos error: {ex.StatusCode}", ex);

--- a/skills/cosmosdb-sdk/AGENTS.md
+++ b/skills/cosmosdb-sdk/AGENTS.md
@@ -721,9 +721,9 @@ Reference: [Query with continuation tokens (Java SDK)](https://learn.microsoft.c
 
 Capture and log diagnostics from Cosmos DB responses, especially for slow or failed operations. Diagnostics contain crucial information for troubleshooting.
 
-`CosmosException.Diagnostics` (type `CosmosDiagnostics`) is the only first-class structured signal the SDK provides for debugging RU spend, latency tails, 429s, region selection, and channel reuse. Demonstrating the pattern is not enough — it must be applied at the point of failure.
+`CosmosException.Diagnostics` (type `CosmosDiagnostics`) is a first-class structured signal the SDK provides for debugging failures (RU spend, latency tails, 429s, region selection, and channel reuse). Demonstrating the pattern is not enough — it must be applied at the point of failure.
 
-**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass such as `CosmosOperationCanceledException`) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation regardless of the block body.
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
 
 **Incorrect (ignoring diagnostics):**
 
@@ -752,7 +752,7 @@ catch (CosmosException ex)
     throw;
 }
 
-// Pattern B — re-wrap, lose Diagnostics entirely (VIOLATION)
+// Pattern B — re-wrap without surfacing Diagnostics (VIOLATION)
 catch (CosmosException ex)
 {
     throw new InvalidOperationException($"Cosmos error: {ex.StatusCode}", ex);

--- a/skills/cosmosdb-sdk/AGENTS.md
+++ b/skills/cosmosdb-sdk/AGENTS.md
@@ -721,6 +721,10 @@ Reference: [Query with continuation tokens (Java SDK)](https://learn.microsoft.c
 
 Capture and log diagnostics from Cosmos DB responses, especially for slow or failed operations. Diagnostics contain crucial information for troubleshooting.
 
+`CosmosException.Diagnostics` (type `CosmosDiagnostics`) is the only first-class structured signal the SDK provides for debugging RU spend, latency tails, 429s, region selection, and channel reuse. Demonstrating the pattern is not enough — it must be applied at the point of failure.
+
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass such as `CosmosOperationCanceledException`) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation regardless of the block body.
+
 **Incorrect (ignoring diagnostics):**
 
 ```csharp
@@ -737,6 +741,27 @@ public async Task<Order> GetOrder(string orderId, string customerId)
         _logger.LogError("Failed to read order: {Message}", ex.Message);
         throw;
     }
+}
+```
+
+```csharp
+// Pattern A — log message text only, drop Diagnostics (VIOLATION)
+catch (CosmosException ex)
+{
+    _logger.LogError(ex, "Cosmos call failed: {Message}", ex.Message);
+    throw;
+}
+
+// Pattern B — re-wrap, lose Diagnostics entirely (VIOLATION)
+catch (CosmosException ex)
+{
+    throw new InvalidOperationException($"Cosmos error: {ex.StatusCode}", ex);
+}
+
+// Pattern C — bare swallow (VIOLATION)
+catch (CosmosException)
+{
+    return null;
 }
 ```
 
@@ -824,6 +849,29 @@ _logger.LogInformation(
 // IndexMetrics shows which indexes were used/not used
 ```
 
+Minimal acceptable catch block — `ex.Diagnostics` is the non-negotiable part. `StatusCode`, `ActivityId`, and `RequestCharge` are strongly recommended (`CosmosDiagnostics.ToString()` includes the latter two, but having them as structured fields makes log search trivial):
+
+```csharp
+catch (CosmosException ex)
+{
+    _logger.LogError(ex,
+        "Cosmos call failed. StatusCode={Status} ActivityId={ActivityId} " +
+        "RequestCharge={RU} Diagnostics={Diagnostics}",
+        ex.StatusCode, ex.ActivityId, ex.RequestCharge, ex.Diagnostics);
+    throw;
+}
+```
+
+If you must re-wrap, carry the diagnostics forward so they are not lost:
+
+```csharp
+catch (CosmosException ex)
+{
+    throw new InvalidOperationException(
+        $"Cosmos error: {ex.StatusCode}. Diagnostics={ex.Diagnostics}", ex);
+}
+```
+
 Key diagnostic fields:
 - `GetClientElapsedTime()`: Total client-side time
 - `RequestCharge`: RU consumed
@@ -831,7 +879,11 @@ Key diagnostic fields:
 - Retry information
 - Connection information
 
-Reference: [Capture diagnostics](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk)
+**Detector (mechanical check):** For each `catch` clause whose declared type binds to `Microsoft.Azure.Cosmos.CosmosException` (or a subclass), verify the block body contains a member access ending in `.Diagnostics` on the caught variable. If absent, flag the catch-block source range. This is expressible as a Roslyn analyzer or a regex over `.cs` files (excluding `bin/`, `obj/`, and test directories).
+
+**Why it matters:** `Diagnostics` carries the RU charge, activity ID, the region the call hit, and the per-channel timing breakdown. On a 429 it also contains the back-end retry hints. Without it, the operator loses exactly the information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
+
+Reference: [Capture diagnostics — Troubleshoot .NET SDK](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk#capture-diagnostics)
 
 ### 1.8 Use Microsoft.Azure.Cosmos package, not abandoned Azure.Cosmos
 

--- a/skills/cosmosdb-sdk/rules/sdk-diagnostics.md
+++ b/skills/cosmosdb-sdk/rules/sdk-diagnostics.md
@@ -9,6 +9,10 @@ tags: sdk, diagnostics, logging, monitoring
 
 Capture and log diagnostics from Cosmos DB responses, especially for slow or failed operations. Diagnostics contain crucial information for troubleshooting.
 
+`CosmosException.Diagnostics` (type `CosmosDiagnostics`) is the only first-class structured signal the SDK provides for debugging RU spend, latency tails, 429s, region selection, and channel reuse. Demonstrating the pattern is not enough — it must be applied at the point of failure.
+
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass such as `CosmosOperationCanceledException`) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation regardless of the block body.
+
 **Incorrect (ignoring diagnostics):**
 
 ```csharp
@@ -25,6 +29,27 @@ public async Task<Order> GetOrder(string orderId, string customerId)
         _logger.LogError("Failed to read order: {Message}", ex.Message);
         throw;
     }
+}
+```
+
+```csharp
+// Pattern A — log message text only, drop Diagnostics (VIOLATION)
+catch (CosmosException ex)
+{
+    _logger.LogError(ex, "Cosmos call failed: {Message}", ex.Message);
+    throw;
+}
+
+// Pattern B — re-wrap, lose Diagnostics entirely (VIOLATION)
+catch (CosmosException ex)
+{
+    throw new InvalidOperationException($"Cosmos error: {ex.StatusCode}", ex);
+}
+
+// Pattern C — bare swallow (VIOLATION)
+catch (CosmosException)
+{
+    return null;
 }
 ```
 
@@ -112,6 +137,29 @@ _logger.LogInformation(
 // IndexMetrics shows which indexes were used/not used
 ```
 
+Minimal acceptable catch block — `ex.Diagnostics` is the non-negotiable part. `StatusCode`, `ActivityId`, and `RequestCharge` are strongly recommended (`CosmosDiagnostics.ToString()` includes the latter two, but having them as structured fields makes log search trivial):
+
+```csharp
+catch (CosmosException ex)
+{
+    _logger.LogError(ex,
+        "Cosmos call failed. StatusCode={Status} ActivityId={ActivityId} " +
+        "RequestCharge={RU} Diagnostics={Diagnostics}",
+        ex.StatusCode, ex.ActivityId, ex.RequestCharge, ex.Diagnostics);
+    throw;
+}
+```
+
+If you must re-wrap, carry the diagnostics forward so they are not lost:
+
+```csharp
+catch (CosmosException ex)
+{
+    throw new InvalidOperationException(
+        $"Cosmos error: {ex.StatusCode}. Diagnostics={ex.Diagnostics}", ex);
+}
+```
+
 Key diagnostic fields:
 - `GetClientElapsedTime()`: Total client-side time
 - `RequestCharge`: RU consumed
@@ -119,4 +167,8 @@ Key diagnostic fields:
 - Retry information
 - Connection information
 
-Reference: [Capture diagnostics](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk)
+**Detector (mechanical check):** For each `catch` clause whose declared type binds to `Microsoft.Azure.Cosmos.CosmosException` (or a subclass), verify the block body contains a member access ending in `.Diagnostics` on the caught variable. If absent, flag the catch-block source range. This is expressible as a Roslyn analyzer or a regex over `.cs` files (excluding `bin/`, `obj/`, and test directories).
+
+**Why it matters:** `Diagnostics` carries the RU charge, activity ID, the region the call hit, and the per-channel timing breakdown. On a 429 it also contains the back-end retry hints. Without it, the operator loses exactly the information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
+
+Reference: [Capture diagnostics — Troubleshoot .NET SDK](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk#capture-diagnostics)

--- a/skills/cosmosdb-sdk/rules/sdk-diagnostics.md
+++ b/skills/cosmosdb-sdk/rules/sdk-diagnostics.md
@@ -11,7 +11,7 @@ Capture and log diagnostics from Cosmos DB responses, especially for slow or fai
 
 `CosmosException.Diagnostics` (type `CosmosDiagnostics`) is the only first-class structured signal the SDK provides for debugging RU spend, latency tails, 429s, region selection, and channel reuse. Demonstrating the pattern is not enough — it must be applied at the point of failure.
 
-**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass such as `CosmosOperationCanceledException`) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation regardless of the block body.
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass such as `CosmosOperationCanceledException`) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A catch block that swallows the exception (e.g., `catch (CosmosException) { }`, or returning `null` / `default` / `new T()`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
 
 **Incorrect (ignoring diagnostics):**
 
@@ -169,6 +169,6 @@ Key diagnostic fields:
 
 **Detector (mechanical check):** For each `catch` clause whose declared type binds to `Microsoft.Azure.Cosmos.CosmosException` (or a subclass), verify the block body contains a member access ending in `.Diagnostics` on the caught variable. If absent, flag the catch-block source range. This is expressible as a Roslyn analyzer or a regex over `.cs` files (excluding `bin/`, `obj/`, and test directories).
 
-**Why it matters:** `Diagnostics` carries the RU charge, activity ID, the region the call hit, and the per-channel timing breakdown. On a 429 it also contains the back-end retry hints. Without it, the operator loses exactly the information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
+**Why it matters:** `RequestCharge` and `ActivityId` provide immediate cost/correlation context, and `Diagnostics` provides the detailed timeline, regions contacted, and retry/transient-failure context (on a 429 it also includes retry details). Without diagnostics, the operator loses the detailed information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
 
 Reference: [Capture diagnostics — Troubleshoot .NET SDK](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk#capture-diagnostics)

--- a/skills/cosmosdb-sdk/rules/sdk-diagnostics.md
+++ b/skills/cosmosdb-sdk/rules/sdk-diagnostics.md
@@ -9,9 +9,9 @@ tags: sdk, diagnostics, logging, monitoring
 
 Capture and log diagnostics from Cosmos DB responses, especially for slow or failed operations. Diagnostics contain crucial information for troubleshooting.
 
-`CosmosException.Diagnostics` (type `CosmosDiagnostics`) is the only first-class structured signal the SDK provides for debugging RU spend, latency tails, 429s, region selection, and channel reuse. Demonstrating the pattern is not enough — it must be applied at the point of failure.
+`CosmosException.Diagnostics` (type `CosmosDiagnostics`) is a first-class structured signal the SDK provides for debugging failures (RU spend, latency tails, 429s, region selection, and channel reuse). Demonstrating the pattern is not enough — it must be applied at the point of failure.
 
-**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass such as `CosmosOperationCanceledException`) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A catch block that swallows the exception (e.g., `catch (CosmosException) { }`, or returning `null` / `default` / `new T()`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A catch block that swallows the exception (e.g., `catch (CosmosException) { }`, or returning `null` / `default` / `new T()`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
 
 **Incorrect (ignoring diagnostics):**
 
@@ -40,7 +40,7 @@ catch (CosmosException ex)
     throw;
 }
 
-// Pattern B — re-wrap, lose Diagnostics entirely (VIOLATION)
+// Pattern B — re-wrap without surfacing Diagnostics (VIOLATION)
 catch (CosmosException ex)
 {
     throw new InvalidOperationException($"Cosmos error: {ex.StatusCode}", ex);


### PR DESCRIPTION
Tighten the sdk-diagnostics acceptance criterion per issue #156: every catch block declaring CosmosException (or subclass) must reference .Diagnostics on the caught variable; forbid bare swallow; add a mechanical detector description and cross-links; deep-link the reference. Applied to both cosmosdb-best-practices and cosmosdb-sdk skills and regenerated AGENTS.md.

## Description

Resolves issue #156, where the existing `sdk-diagnostics` rule achieved 0/38 adoption because its guidance was aspirational ("log diagnostics") rather than a checkable acceptance criterion. This PR rewrites the rule around a strict syntactic minimum and makes it mechanically enforceable:

- Adds a **strict syntactic minimum**: every `catch` that declares `CosmosException` (or a subclass) must reference `.Diagnostics` on the caught variable somewhere inside the block.
- Documents three **violation patterns**: (A) log-message-only with no diagnostics, (B) re-wrap that drops diagnostics, (C) bare swallow (`catch (CosmosException) { }`).
- Provides a **minimal acceptable catch block** logging `StatusCode`, `ActivityId`, `RequestCharge`, and `Diagnostics`, plus a diagnostics-preserving re-wrap variant.
- Adds a **mechanical detector** description (Roslyn/regex: find each `catch` binding `CosmosException`/subclass, verify a `.Diagnostics` member access on the caught variable in the body; exclude `bin/`, `obj/`, tests).
- Adds **"Why it matters"** cross-links to the throughput/RU and 429/retry rules, and **deep-links** the reference to the `#capture-diagnostics` anchor.
- Applied identically to the monolith `cosmosdb-best-practices` skill and the split `cosmosdb-sdk` skill, and regenerated both `AGENTS.md` files via `npm run build`.

## Type of Change

- [ ] 📝 New rule - Adding a new best practice rule
- [x] ✏️ Rule improvement - Updating an existing rule
- [ ] 🆕 New skill - Adding an entirely new skill
- [ ] 🐛 Bug fix - Fixing an issue with existing content
- [ ] 📚 Documentation - Updating README, CONTRIBUTING, or other docs
- [ ] 🔧 Build/Scripts - Changes to build process or scripts

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/blob/main/CONTRIBUTING.md)
- [ ] I ran `npm run validate` and it passed — see note below
- [x] I ran `npm run build` to regenerate AGENTS.md (if adding/updating rules)
- [x] My rule file follows the naming convention: `{prefix}-{description}.md` (`sdk-diagnostics.md`)
- [x] My rule includes valid frontmatter (`title`, `impact`, `tags`)

> **Note on `npm run validate`:** the validator reports 42 errors, but all of them are **pre-existing on `main`** and live in **files unrelated to this PR** (e.g. `throughput-container-vs-database.md`, `sdk-serialization-enums.md`, `sdk-newtonsoft-dependency.md`, `index-range-vs-hash.md`, etc.). Verified via `git stash` → the same 42 errors remain without my changes. `sdk-diagnostics.md` validates cleanly in both skills (`[cosmosdb-best-practices] 116 rules validated`, `[cosmosdb-sdk] 34 rules validated`).

## Agent Testing

Verified the rewritten rule drives compliant generation. Acting as a coding agent under the updated rule, I generated a representative .NET repository (read / create / query / delete / patch-with-429 — 9 `catch (CosmosException ...)` blocks) and ran the rule's own mechanical detector:

- **Compliant generation:** 9/9 catch blocks reference `.Diagnostics` → 0 misses (vs. the 0/38 baseline in #156).
- **Negative control:** the three documented violation patterns (A/B/C) were all correctly flagged as missing, while the compliant block passed (3/4 miss) — confirming the detector discriminates rather than rubber-stamping.

- [x] Tested with GitHub Copilot
- [ ] Tested with Claude Code
- [ ] Tested with Cursor
- [ ] Tested with other agent: _____
- [ ] N/A (documentation only)

## Related Issues

Closes #156

## Additional Notes

- Files changed: `skills/cosmosdb-best-practices/rules/sdk-diagnostics.md`, `skills/cosmosdb-best-practices/AGENTS.md`, `skills/cosmosdb-sdk/rules/sdk-diagnostics.md`, `skills/cosmosdb-sdk/AGENTS.md`, `CHANGELOG.md`.
- The rule is duplicated in both skills because the repo is mid-transition (PR #204): the monolith `cosmosdb-best-practices` skill coexists with the 13 split topic skills, so an `sdk-` rule must live in both until the monolith is retired.
- Rule frontmatter unchanged: `impact: MEDIUM`, `tags: sdk, diagnostics, logging, monitoring`.