### PR TITLE
feat(partition): add query-pattern tie-breaker guidance

### DIFF
--- a/skills/cosmosdb-best-practices/rules/partition-high-cardinality.md
+++ b/skills/cosmosdb-best-practices/rules/partition-high-cardinality.md
@@ -81,9 +81,9 @@ Good partition keys typically:
 
 High cardinality is important for even distribution, but it should not be the sole factor when selecting a partition key.
 
-For read-heavy workloads that can grow to multiple physical partitions and where most queries use an equality filter on a specific field, prefer a partition key aligned with that dominant query pattern even if its cardinality is lower than `/id`. Single-partition reads are often more efficient than cross-partition fan-out for the dominant access pattern.
+For read-heavy workloads that can grow to multiple physical partitions and where most queries use an equality filter on a specific field, prefer a partition key aligned with that dominant query pattern even if its cardinality is lower than `/id`, as long as it still provides sufficient cardinality to avoid hot partitions. If the query-aligned field is too low-cardinality, consider a synthetic or hierarchical partition key to preserve query alignment while improving distribution.
 
-A bare `/id` partition key is most appropriate when point reads by `/id` are the dominant access pattern, when the container is small enough that cross-partition fan-out is not a concern, or when write throughput requires maximum distribution. If the dominant query pattern filters on another field, consider whether aligning the partition key with that field would reduce cross-partition queries.
+A bare `/id` partition key is most appropriate when point reads by `/id` are the dominant access pattern, when the container is small enough to remain within a single physical partition, or when write throughput requires maximum distribution. If the dominant query pattern filters on another field, consider whether aligning the partition key with that field would reduce cross-partition queries.
 
 See also: `partition-query-patterns`.
 

--- a/skills/cosmosdb-best-practices/rules/partition-high-cardinality.md
+++ b/skills/cosmosdb-best-practices/rules/partition-high-cardinality.md
@@ -77,4 +77,14 @@ Good partition keys typically:
 - Match your most common query patterns
 - Distribute writes evenly (no single key dominates)
 
+### Cardinality vs. Query Patterns
+
+High cardinality is important for even distribution, but it should not be the sole factor when selecting a partition key.
+
+For read-heavy workloads where most queries filter on a specific field, prefer a partition key aligned with the dominant query pattern even if its cardinality is lower than `/id`. Single-partition reads are often more efficient than maximizing distribution that the workload does not require.
+
+A bare `/id` partition key is most appropriate when point reads by id are the dominant access pattern or when write throughput requires maximum distribution. If the dominant query pattern filters on another field, consider whether aligning the partition key with that field would reduce cross-partition queries.
+
+See also: `partition-query-patterns`.
+
 Reference: [Partitioning in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/partitioning-overview)

--- a/skills/cosmosdb-best-practices/rules/partition-high-cardinality.md
+++ b/skills/cosmosdb-best-practices/rules/partition-high-cardinality.md
@@ -81,9 +81,9 @@ Good partition keys typically:
 
 High cardinality is important for even distribution, but it should not be the sole factor when selecting a partition key.
 
-For read-heavy workloads where most queries filter on a specific field, prefer a partition key aligned with the dominant query pattern even if its cardinality is lower than `/id`. Single-partition reads are often more efficient than maximizing distribution that the workload does not require.
+For read-heavy workloads that can grow to multiple physical partitions and where most queries use an equality filter on a specific field, prefer a partition key aligned with that dominant query pattern even if its cardinality is lower than `/id`. Single-partition reads are often more efficient than cross-partition fan-out for the dominant access pattern.
 
-A bare `/id` partition key is most appropriate when point reads by id are the dominant access pattern or when write throughput requires maximum distribution. If the dominant query pattern filters on another field, consider whether aligning the partition key with that field would reduce cross-partition queries.
+A bare `/id` partition key is most appropriate when point reads by `/id` are the dominant access pattern, when the container is small enough that cross-partition fan-out is not a concern, or when write throughput requires maximum distribution. If the dominant query pattern filters on another field, consider whether aligning the partition key with that field would reduce cross-partition queries.
 
 See also: `partition-query-patterns`.
 

--- a/skills/cosmosdb-best-practices/rules/partition-query-patterns.md
+++ b/skills/cosmosdb-best-practices/rules/partition-query-patterns.md
@@ -85,9 +85,9 @@ public class Message
 
 ### Query Alignment vs. Cardinality
 
-When query-pattern guidance conflicts with pure cardinality guidance, favor the partition key that supports the dominant access pattern for read-heavy workloads.
+When query-pattern guidance conflicts with pure cardinality guidance, favor the partition key that supports the dominant access pattern, especially for read-heavy workloads that can grow to multiple physical partitions.
 
-For example, if most queries filter by `Category`, partitioning by `Category` may be preferable to partitioning by `/id`, even though `/id` provides higher cardinality. This keeps the dominant queries single-partition and avoids unnecessary cross-partition scans.
+For example, if most queries use an equality filter by `Category`, partitioning by `Category` may be preferable to partitioning by `/id`, even though `/id` provides higher cardinality. This keeps the dominant queries single-partition (when you supply the `PartitionKey` value) and avoids unnecessary cross-partition fan-out.
 
 If the query field has insufficient cardinality and may create hot partitions, consider a synthetic or hierarchical partition key that preserves query alignment while improving distribution.
 

--- a/skills/cosmosdb-best-practices/rules/partition-query-patterns.md
+++ b/skills/cosmosdb-best-practices/rules/partition-query-patterns.md
@@ -83,4 +83,14 @@ public class Message
 // "Get messages in conversation" - single partition, fast
 ```
 
+### Query Alignment vs. Cardinality
+
+When query-pattern guidance conflicts with pure cardinality guidance, favor the partition key that supports the dominant access pattern for read-heavy workloads.
+
+For example, if most queries filter by `Category`, partitioning by `Category` may be preferable to partitioning by `/id`, even though `/id` provides higher cardinality. This keeps the dominant queries single-partition and avoids unnecessary cross-partition scans.
+
+If the query field has insufficient cardinality and may create hot partitions, consider a synthetic or hierarchical partition key that preserves query alignment while improving distribution.
+
+See also: `partition-high-cardinality`.
+
 Reference: [Choose a partition key](https://learn.microsoft.com/azure/cosmos-db/partitioning-overview#choose-a-partition-key)

--- a/skills/cosmosdb-best-practices/rules/partition-query-patterns.md
+++ b/skills/cosmosdb-best-practices/rules/partition-query-patterns.md
@@ -87,7 +87,7 @@ public class Message
 
 When query-pattern guidance conflicts with pure cardinality guidance, favor the partition key that supports the dominant access pattern, especially for read-heavy workloads that can grow to multiple physical partitions.
 
-For example, if most queries use an equality filter by `Category`, partitioning by `Category` may be preferable to partitioning by `/id`, even though `/id` provides higher cardinality. This keeps the dominant queries single-partition (when you supply the `PartitionKey` value) and avoids unnecessary cross-partition fan-out.
+For example, if most queries use an equality filter on `/category` (and `category` has sufficient cardinality to avoid hot partitions), partitioning by `/category` may be preferable to partitioning by `/id`, even though `/id` provides higher cardinality. This keeps the dominant queries single-partition (when you supply the `PartitionKey` value) and avoids unnecessary cross-partition fan-out.
 
 If the query field has insufficient cardinality and may create hot partitions, consider a synthetic or hierarchical partition key that preserves query alignment while improving distribution.
 

--- a/skills/cosmosdb-best-practices/rules/partition-query-patterns.md
+++ b/skills/cosmosdb-best-practices/rules/partition-query-patterns.md
@@ -89,7 +89,7 @@ When query-pattern guidance conflicts with pure cardinality guidance, favor the 
 
 For example, if most queries use an equality filter on `/category` (and `category` has sufficient cardinality to avoid hot partitions), partitioning by `/category` may be preferable to partitioning by `/id`, even though `/id` provides higher cardinality. This keeps the dominant queries single-partition (when you supply the `PartitionKey` value) and avoids unnecessary cross-partition fan-out.
 
-If the query field has insufficient cardinality and may create hot partitions, consider a synthetic or hierarchical partition key that preserves query alignment while improving distribution.
+If `/category` has insufficient cardinality and may create hot partitions, consider a synthetic or hierarchical partition key that preserves query alignment while improving distribution.
 
 See also: `partition-high-cardinality`.
 


### PR DESCRIPTION
## Description

Adds tie-breaker guidance for partition key selection when high cardinality and query-pattern alignment conflict.

This update clarifies that for read-heavy workloads, aligning the partition key with the dominant access pattern may be preferable to maximizing cardinality with `/id`, while preserving existing guidance that `/id` remains appropriate for point-read-dominated and write-heavy workloads.

## Type of Change

* [ ] 📝 New rule - Adding a new best practice rule
* [x] ✏️ Rule improvement - Updating an existing rule
* [ ] 🆕 New skill - Adding an entirely new skill
* [ ] 🐛 Bug fix - Fixing an issue with existing content
* [ ] 📚 Documentation - Updating README, CONTRIBUTING, or other docs
* [ ] 🔧 Build/Scripts - Changes to build process or scripts

## Checklist

* [x] I have read the Contributing Guide
* [ ] I ran `npm run validate` and it passed *(repository currently contains unrelated validation failures)*
* [x] I ran `npm run build` to regenerate AGENTS.md (if adding/updating rules)
* [x] My rule file follows the naming convention: `{prefix}-{description}.md`
* [x] My rule includes valid frontmatter (`title`, `impact`, `tags`)

## Agent Testing

* [ ] Tested with GitHub Copilot
* [ ] Tested with Claude Code
* [ ] Tested with Cursor
* [ ] Tested with other agent: _____
* [x] N/A (documentation/rule guidance update)

## Related Issues

Fixes #201

## Additional Notes

Updated:

* `partition-high-cardinality.md`
* `partition-query-patterns.md`

Added explicit precedence guidance for cases where high cardinality and query-pattern alignment suggest different partition keys. The update preserves valid `/id` partition key scenarios while clarifying when query-pattern alignment should take precedence for read-heavy workloads.
