### PR TITLE
Improve split-skill routing: co-select SDK + vector-search + design-patterns for RAG API tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This is the high-level log. For detailed per-iteration evaluation notes (test re
 
 ---
 
+## 2026-06-18 — Split-skill routing: co-select SDK + vector-search + design-patterns for RAG API tasks
+
+- **Routing:** Added a shared `RAG API` trigger cluster and mutual `COMPANION SKILLS` cross-references to the `description` frontmatter of the `cosmosdb-sdk`, `cosmosdb-vector-search`, and `cosmosdb-design-patterns` skills so a RAG API task selects all three together — SDK client + embedding ingestion, vector index + `VectorDistance` retrieval, and retrieval orchestration + grounding.
+- **Refinement:** Softened the `cosmosdb-design-patterns` exclusion from "SDK configuration" to "SDK configuration alone" so RAG orchestration work is no longer routed entirely away from it.
+- No rule content or compiled `AGENTS.md` changes — this is a discoverability/routing-only update to three `SKILL.md` descriptions.
+
 ## 2026-06-15 — `sdk-go-partition-key-metadata`: Go cross-SDK partition metadata guidance ([#161](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/issues/161))
 
 - **New rule:** `sdk-go-partition-key-metadata.md` — Instructs agents to avoid stale `azcosmos` pins, prefer current Go SDK releases, and create single-path partition keys with explicit metadata that interoperates with other Cosmos DB SDKs used by verifiers.

--- a/skills/cosmosdb-design-patterns/SKILL.md
+++ b/skills/cosmosdb-design-patterns/SKILL.md
@@ -9,8 +9,12 @@ description: |
   USE FOR: Cosmos DB change feed, materialized views, CQRS, event sourcing,
   ranking patterns, service layer, relationship hydration, LangGraph, multi-agent,
   human-in-the-loop, interrupt, checkpoint, agent routing, FastAPI startup,
-  chat history, background tasks, async routing, agent attribution, AI grounding.
-  DO NOT USE FOR: SDK configuration (use cosmosdb-sdk), data modeling (use cosmosdb-data-modeling).
+  chat history, background tasks, async routing, agent attribution, AI grounding,
+  RAG API, RAG orchestration, retrieval pipeline, grounding retrieval.
+  COMPANION SKILLS: for RAG API tasks, apply this skill together with
+  cosmosdb-vector-search (vector index + VectorDistance retrieval) and
+  cosmosdb-sdk (CosmosClient setup + embedding ingestion).
+  DO NOT USE FOR: SDK configuration alone (use cosmosdb-sdk), data modeling (use cosmosdb-data-modeling).
 
 license: MIT
 metadata:

--- a/skills/cosmosdb-sdk/SKILL.md
+++ b/skills/cosmosdb-sdk/SKILL.md
@@ -12,7 +12,11 @@ description: |
   Spring Data Cosmos, Spring Boot versions, Newtonsoft dependency, namespace collision,
   Python async deps, local dev config, LangChain Cosmos DB saver, LangGraph checkpointer,
   MCP persistent session, MCP tool content format, MCP tool filtering,
-  LangChain JS vectorstore, LangChain JS chat history, LangChain JS semantic cache.
+  LangChain JS vectorstore, LangChain JS chat history, LangChain JS semantic cache,
+  RAG API, RAG pipeline, RAG application, vector store client for RAG, embedding ingestion.
+  COMPANION SKILLS: for RAG API tasks, apply this skill together with
+  cosmosdb-vector-search (vector index + VectorDistance retrieval) and
+  cosmosdb-design-patterns (retrieval orchestration and grounding).
   DO NOT USE FOR: data modeling (use cosmosdb-data-modeling), queries (use cosmosdb-query-optimization),
   partition keys (use cosmosdb-partition-key).
 

--- a/skills/cosmosdb-vector-search/SKILL.md
+++ b/skills/cosmosdb-vector-search/SKILL.md
@@ -6,8 +6,12 @@ description: |
   normalizing embeddings, VectorDistance queries, and repository patterns for RAG.
   USE FOR: Cosmos DB vector search, vector embedding policy, vector index,
   flat index, quantizedFlat, diskANN, VectorDistance, cosine similarity,
-  embedding normalization, RAG, retrieval augmented generation, semantic search,
-  vector repository pattern, AI search.
+  embedding normalization, RAG, RAG API, RAG pipeline, RAG application,
+  retrieval augmented generation, semantic search,
+  vector repository pattern, AI search, grounding retrieval.
+  COMPANION SKILLS: for RAG API tasks, apply this skill together with
+  cosmosdb-sdk (CosmosClient setup + embedding ingestion) and
+  cosmosdb-design-patterns (retrieval orchestration and grounding).
   DO NOT USE FOR: full-text search (use cosmosdb-full-text-search),
   LangChain integration (use cosmosdb-sdk or cosmosdb-design-patterns).
 


### PR DESCRIPTION
## Summary

Improves split-skill routing so that a **RAG API** task selects the three relevant skills together instead of one at a time:

- `cosmosdb-sdk` — CosmosClient setup + embedding ingestion
- `cosmosdb-vector-search` — vector index + `VectorDistance` retrieval
- `cosmosdb-design-patterns` — retrieval orchestration + grounding

Previously, only `cosmosdb-vector-search` mentioned RAG, and the `DO NOT USE FOR` lines in `cosmosdb-sdk` / `cosmosdb-design-patterns` pushed RAG work away from them, so an agent building a RAG API would not reliably load the full stack.

## Changes

Description-only edits to three `SKILL.md` frontmatter blocks:

- **Added a shared `RAG API` trigger cluster** to the `USE FOR` lists of all three skills (`RAG API, RAG pipeline, RAG application`, plus skill-specific phrasing like `embedding ingestion`, `grounding retrieval`, `RAG orchestration`).
- **Added a `COMPANION SKILLS` line** to each description that explicitly names the other two as companions for RAG API tasks, so the agent co-selects the full set.
- **Softened** the `cosmosdb-design-patterns` exclusion from `SDK configuration` to `SDK configuration alone`, so RAG orchestration work is no longer routed entirely away from it.

## Scope / safety

- No rule content changed and no compiled `AGENTS.md` changed — this is a discoverability/routing-only update.
- YAML frontmatter validated on all three files (description block parses; triggers present).
- `npm run build` compiles cleanly (243 rules across 14 skills).
- CHANGELOG entry added.
