### PR TITLE
Add rule: throughput-idle-container-review

### DIFF
--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -9326,7 +9326,7 @@ Reference: [Throughput on containers vs databases](https://learn.microsoft.com/a
 
 ## Review Idle Containers for Lifecycle Action
 
-A container with near-zero traffic still bills for throughput: **manual** provisioning bills its full RU/s 24/7, and **autoscale** bills each hour for the highest RU/s it scaled to that hour (between 10% and 100% of the configured max) — so an idle autoscale container still bills the 10% minimum. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers that cost is **decommissioning the container** (or dropping it to the minimum RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
+A container with near-zero traffic still bills for throughput: **manual** provisioning bills its full RU/s 24/7, and **autoscale** [bills each hour for the highest RU/s it scaled to that hour](https://learn.microsoft.com/azure/cosmos-db/provision-throughput-autoscale) (between 10% and 100% of the configured max) — so an idle autoscale container still bills the 10% minimum. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers that cost is **decommissioning the container** (or dropping it to the minimum RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
 
 **Incorrect (leaving an abandoned container provisioned):**
 
@@ -9362,9 +9362,7 @@ Safety gates before removing an idle container:
 
 This differs from `throughput-right-size`, which tunes an *active but oversized* container; here the container is effectively unused and the question is whether it should exist at all.
 
-References:
-- [Time to Live (TTL) in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)
-- [Provisioned throughput with autoscale (billing model)](https://learn.microsoft.com/azure/cosmos-db/provision-throughput-autoscale)
+Reference: [Time to Live (TTL) in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)
 
 ### 6.5 Right-Size Provisioned Throughput
 

--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -9326,7 +9326,7 @@ Reference: [Throughput on containers vs databases](https://learn.microsoft.com/a
 
 ## Review Idle Containers for Lifecycle Action
 
-A container with near-zero traffic still bills for throughput: **manual** provisioning bills its full RU/s 24/7, and **autoscale** [bills each hour for the highest RU/s it scaled to that hour](https://learn.microsoft.com/azure/cosmos-db/provision-throughput-autoscale) (between 10% and 100% of the configured max) — so an idle autoscale container still bills the 10% minimum. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers that cost is **decommissioning the container** (or dropping it to the minimum RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
+A container on **dedicated (provisioned) throughput** still bills for that throughput at near-zero traffic: **manual** bills its full RU/s 24/7, and **autoscale** [bills each hour for the highest RU/s it scaled to that hour](https://learn.microsoft.com/azure/cosmos-db/provision-throughput-autoscale) (between 10% and 100% of the configured max) — so an idle autoscale container still bills the 10% minimum. (This rule targets that case. A **serverless** container bills per request, so idle costs nothing; a container on database-level **shared** throughput doesn't bill on its own — the RU/s belongs to the database.) Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers the cost is **decommissioning the container** (or dropping its RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
 
 **Incorrect (leaving an abandoned container provisioned):**
 
@@ -9358,7 +9358,7 @@ Safety gates before removing an idle container:
 1. Confirm the container is genuinely idle (no reads or writes over a representative window, not just low RU).
 2. Get owner approval and check retention/compliance requirements.
 3. Take and validate a backup or export.
-4. TTL/archival control *data retention*, not throughput cost — to stop paying, delete the container (or lower its RU/s). Delete only after monitoring confirms nothing depends on it.
+4. TTL/archival control *data retention*, not throughput cost. To recover **dedicated** throughput, delete the container (or lower its RU/s); on **shared** database throughput, deleting frees RU back to the database; **serverless** has no idle charge. Delete only after monitoring confirms nothing depends on it.
 
 This differs from `throughput-right-size`, which tunes an *active but oversized* container; here the container is effectively unused and the question is whether it should exist at all.
 

--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -105,8 +105,9 @@ Performance optimization and best practices guide for Azure Cosmos DB applicatio
    - 6.1 [Use Autoscale for Variable Workloads](#61-use-autoscale-for-variable-workloads)
    - 6.2 [Understand Burst Capacity](#62-understand-burst-capacity)
    - 6.3 [Choose Container vs Database Throughput](#63-choose-container-vs-database-throughput)
-   - 6.4 [Right-Size Provisioned Throughput](#64-right-size-provisioned-throughput)
-   - 6.5 [Consider Serverless for Dev/Test](#65-consider-serverless-for-dev-test)
+   - 6.4 [Review Idle Containers for Lifecycle Action](#64-review-idle-containers-for-lifecycle-action)
+   - 6.5 [Right-Size Provisioned Throughput](#65-right-size-provisioned-throughput)
+   - 6.6 [Consider Serverless for Dev/Test](#66-consider-serverless-for-dev-test)
 7. [Global Distribution](#7-global-distribution) — **MEDIUM**
    - 7.1 [Implement Conflict Resolution](#71-implement-conflict-resolution)
    - 7.2 [Choose Appropriate Consistency Level](#72-choose-appropriate-consistency-level)
@@ -4269,7 +4270,7 @@ Capture and log diagnostics from Cosmos DB responses, especially for slow or fai
 
 `CosmosException.Diagnostics` (type `CosmosDiagnostics`) is a first-class structured signal the SDK provides for debugging failures (RU spend, latency tails, 429s, region selection, and channel reuse). Demonstrating the pattern is not enough — it must be applied at the point of failure.
 
-**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A catch block that swallows the exception (e.g., `catch (CosmosException) { }`, or returning `null` / `default` / `new T()`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
 
 **Incorrect (ignoring diagnostics):**
 
@@ -4427,7 +4428,7 @@ Key diagnostic fields:
 
 **Detector (mechanical check):** For each `catch` clause whose declared type binds to `Microsoft.Azure.Cosmos.CosmosException` (or a subclass), verify the block body contains a member access ending in `.Diagnostics` on the caught variable. If absent, flag the catch-block source range. This is expressible as a Roslyn analyzer or a regex over `.cs` files (excluding `bin/`, `obj/`, and test directories).
 
-**Why it matters:** `Diagnostics` carries the RU charge, activity ID, the region the call hit, and the per-channel timing breakdown. On a 429 it also contains the back-end retry hints. Without it, the operator loses exactly the information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
+**Why it matters:** `RequestCharge` and `ActivityId` provide immediate cost/correlation context, and `Diagnostics` provides the detailed timeline, regions contacted, and retry/transient-failure context (on a 429 it also includes retry details). Without diagnostics, the operator loses the detailed information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
 
 Reference: [Capture diagnostics — Troubleshoot .NET SDK](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk#capture-diagnostics)
 
@@ -9319,7 +9320,51 @@ Decision matrix:
 
 Reference: [Throughput on containers vs databases](https://learn.microsoft.com/azure/cosmos-db/set-throughput)
 
-### 6.4 Right-Size Provisioned Throughput
+### 6.4 Review Idle Containers for Lifecycle Action
+
+**Impact: MEDIUM** (recovers provisioned or autoscale-floor capacity)
+
+## Review Idle Containers for Lifecycle Action
+
+A container with near-zero traffic still carries its provisioned throughput — or an autoscale floor (10% of the configured max) — which is billed even while it sits idle. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers that cost is **decommissioning the container** (or dropping it to the minimum RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
+
+**Incorrect (leaving an abandoned container provisioned):**
+
+```csharp
+// Legacy import container kept after a migration; no application reads or writes it,
+// yet it bills the 400 RU/s floor continuously.
+await database.CreateContainerIfNotExistsAsync(
+    new ContainerProperties("legacy-imports", "/tenantId"),
+    throughput: 400);
+```
+
+**Correct (decommission to recover cost; TTL only handles data retention):**
+
+```csharp
+// NOTE: TTL only expires data — it does NOT reduce the provisioned/autoscale RU bill.
+// Recovering the throughput cost requires decommissioning the container (or, if it must
+// stay, dropping it to the minimum RU/s).
+
+// 1. Optional retention: expire remaining data instead of holding it forever.
+var properties = await container.ReadContainerAsync();
+properties.Resource.DefaultTimeToLive = 60 * 60 * 24 * 30; // retain 30 days
+await container.ReplaceContainerAsync(properties.Resource);
+
+// 2. After owner approval and a validated backup/export, delete it to stop paying:
+// await container.DeleteContainerAsync();
+```
+
+Safety gates before removing an idle container:
+1. Confirm the container is genuinely idle (no reads or writes over a representative window, not just low RU).
+2. Get owner approval and check retention/compliance requirements.
+3. Take and validate a backup or export.
+4. TTL/archival control *data retention*, not throughput cost — to stop paying, delete the container (or lower its RU/s). Delete only after monitoring confirms nothing depends on it.
+
+This differs from `throughput-right-size`, which tunes an *active but oversized* container; here the container is effectively unused and the question is whether it should exist at all.
+
+Reference: [Time to Live (TTL) in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)
+
+### 6.5 Right-Size Provisioned Throughput
 
 **Impact: MEDIUM** (balances performance and cost)
 
@@ -9411,7 +9456,7 @@ Throughput guidance:
 
 Reference: [Estimate RU/s](https://learn.microsoft.com/azure/cosmos-db/estimate-ru-with-capacity-planner)
 
-### 6.5 Consider Serverless for Dev/Test
+### 6.6 Consider Serverless for Dev/Test
 
 **Impact: MEDIUM** (pay-per-request pricing)
 

--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -4270,7 +4270,7 @@ Capture and log diagnostics from Cosmos DB responses, especially for slow or fai
 
 `CosmosException.Diagnostics` (type `CosmosDiagnostics`) is a first-class structured signal the SDK provides for debugging failures (RU spend, latency tails, 429s, region selection, and channel reuse). Demonstrating the pattern is not enough — it must be applied at the point of failure.
 
-**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A catch block that swallows the exception (e.g., `catch (CosmosException) { }`, or returning `null` / `default` / `new T()`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
 
 **Incorrect (ignoring diagnostics):**
 
@@ -4428,7 +4428,7 @@ Key diagnostic fields:
 
 **Detector (mechanical check):** For each `catch` clause whose declared type binds to `Microsoft.Azure.Cosmos.CosmosException` (or a subclass), verify the block body contains a member access ending in `.Diagnostics` on the caught variable. If absent, flag the catch-block source range. This is expressible as a Roslyn analyzer or a regex over `.cs` files (excluding `bin/`, `obj/`, and test directories).
 
-**Why it matters:** `RequestCharge` and `ActivityId` provide immediate cost/correlation context, and `Diagnostics` provides the detailed timeline, regions contacted, and retry/transient-failure context (on a 429 it also includes retry details). Without diagnostics, the operator loses the detailed information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
+**Why it matters:** `Diagnostics` carries the RU charge, activity ID, the region the call hit, and the per-channel timing breakdown. On a 429 it also contains the back-end retry hints. Without it, the operator loses exactly the information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
 
 Reference: [Capture diagnostics — Troubleshoot .NET SDK](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk#capture-diagnostics)
 
@@ -9326,7 +9326,7 @@ Reference: [Throughput on containers vs databases](https://learn.microsoft.com/a
 
 ## Review Idle Containers for Lifecycle Action
 
-A container with near-zero traffic still carries its provisioned throughput — or an autoscale floor (10% of the configured max) — which is billed even while it sits idle. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers that cost is **decommissioning the container** (or dropping it to the minimum RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
+A container with near-zero traffic still bills for throughput: **manual** provisioning bills its full RU/s 24/7, and **autoscale** bills each hour for the highest RU/s it scaled to that hour (between 10% and 100% of the configured max) — so an idle autoscale container still bills the 10% minimum. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers that cost is **decommissioning the container** (or dropping it to the minimum RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
 
 **Incorrect (leaving an abandoned container provisioned):**
 
@@ -9362,7 +9362,9 @@ Safety gates before removing an idle container:
 
 This differs from `throughput-right-size`, which tunes an *active but oversized* container; here the container is effectively unused and the question is whether it should exist at all.
 
-Reference: [Time to Live (TTL) in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)
+References:
+- [Time to Live (TTL) in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)
+- [Provisioned throughput with autoscale (billing model)](https://learn.microsoft.com/azure/cosmos-db/provision-throughput-autoscale)
 
 ### 6.5 Right-Size Provisioned Throughput
 

--- a/skills/cosmosdb-best-practices/SKILL.md
+++ b/skills/cosmosdb-best-practices/SKILL.md
@@ -145,6 +145,7 @@ Reference these guidelines when:
 - [throughput-serverless](rules/throughput-serverless.md) - Consider serverless for dev/test
 - [throughput-burst](rules/throughput-burst.md) - Understand burst capacity
 - [throughput-container-vs-database](rules/throughput-container-vs-database.md) - Choose allocation level wisely
+- [throughput-idle-container-review](rules/throughput-idle-container-review.md) - Review idle containers for lifecycle action
 
 ### 7. Global Distribution (MEDIUM)
 

--- a/skills/cosmosdb-best-practices/rules/throughput-idle-container-review.md
+++ b/skills/cosmosdb-best-practices/rules/throughput-idle-container-review.md
@@ -1,0 +1,42 @@
+---
+title: Review Idle Containers for Lifecycle Action
+impact: MEDIUM
+impactDescription: recovers provisioned or autoscale-floor capacity
+tags: throughput, lifecycle, idle, ttl, decommission, cost
+---
+
+## Review Idle Containers for Lifecycle Action
+
+A container with near-zero traffic still carries its provisioned throughput, or an autoscale floor (10% of the configured max) that is billed even while idle. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. Before deleting anything, confirm retention, compliance, and recovery requirements; then decommission, archive, or apply TTL so unused data and capacity do not persist and bill indefinitely.
+
+**Incorrect (leaving an abandoned container provisioned):**
+
+```csharp
+// Legacy import container kept after a migration; no application reads or writes it,
+// yet it bills the 400 RU/s floor continuously.
+await database.CreateContainerIfNotExistsAsync(
+    new ContainerProperties("legacy-imports", "/tenantId"),
+    throughput: 400);
+```
+
+**Correct (apply TTL and decommission after validation):**
+
+```csharp
+// Expire remaining data on a retention window instead of holding it forever.
+var properties = await container.ReadContainerAsync();
+properties.Resource.DefaultTimeToLive = 60 * 60 * 24 * 30; // retain 30 days
+await container.ReplaceContainerAsync(properties.Resource);
+
+// After owner approval and a validated backup/export:
+// await container.DeleteContainerAsync();
+```
+
+Safety gates before removing an idle container:
+1. Confirm the container is genuinely idle (no reads or writes over a representative window, not just low RU).
+2. Get owner approval and check retention/compliance requirements.
+3. Take and validate a backup or export.
+4. Prefer TTL or archival first; delete only after monitoring confirms nothing depends on it.
+
+This differs from `throughput-right-size`, which tunes an *active but oversized* container; here the container is effectively unused and the question is whether it should exist at all.
+
+Reference: [Time to Live (TTL) in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)

--- a/skills/cosmosdb-best-practices/rules/throughput-idle-container-review.md
+++ b/skills/cosmosdb-best-practices/rules/throughput-idle-container-review.md
@@ -7,7 +7,7 @@ tags: throughput, lifecycle, idle, ttl, decommission, cost
 
 ## Review Idle Containers for Lifecycle Action
 
-A container with near-zero traffic still bills for throughput: **manual** provisioning bills its full RU/s 24/7, and **autoscale** bills each hour for the highest RU/s it scaled to that hour (between 10% and 100% of the configured max) — so an idle autoscale container still bills the 10% minimum. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers that cost is **decommissioning the container** (or dropping it to the minimum RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
+A container with near-zero traffic still bills for throughput: **manual** provisioning bills its full RU/s 24/7, and **autoscale** [bills each hour for the highest RU/s it scaled to that hour](https://learn.microsoft.com/azure/cosmos-db/provision-throughput-autoscale) (between 10% and 100% of the configured max) — so an idle autoscale container still bills the 10% minimum. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers that cost is **decommissioning the container** (or dropping it to the minimum RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
 
 **Incorrect (leaving an abandoned container provisioned):**
 
@@ -43,6 +43,4 @@ Safety gates before removing an idle container:
 
 This differs from `throughput-right-size`, which tunes an *active but oversized* container; here the container is effectively unused and the question is whether it should exist at all.
 
-References:
-- [Time to Live (TTL) in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)
-- [Provisioned throughput with autoscale (billing model)](https://learn.microsoft.com/azure/cosmos-db/provision-throughput-autoscale)
+Reference: [Time to Live (TTL) in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)

--- a/skills/cosmosdb-best-practices/rules/throughput-idle-container-review.md
+++ b/skills/cosmosdb-best-practices/rules/throughput-idle-container-review.md
@@ -7,7 +7,7 @@ tags: throughput, lifecycle, idle, ttl, decommission, cost
 
 ## Review Idle Containers for Lifecycle Action
 
-A container with near-zero traffic still carries its provisioned throughput, or an autoscale floor (10% of the configured max) that is billed even while idle. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. Before deleting anything, confirm retention, compliance, and recovery requirements; then decommission, archive, or apply TTL so unused data and capacity do not persist and bill indefinitely.
+A container with near-zero traffic still carries its provisioned throughput — or an autoscale floor (10% of the configured max) — which is billed even while it sits idle. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers that cost is **decommissioning the container** (or dropping it to the minimum RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
 
 **Incorrect (leaving an abandoned container provisioned):**
 
@@ -19,15 +19,19 @@ await database.CreateContainerIfNotExistsAsync(
     throughput: 400);
 ```
 
-**Correct (apply TTL and decommission after validation):**
+**Correct (decommission to recover cost; TTL only handles data retention):**
 
 ```csharp
-// Expire remaining data on a retention window instead of holding it forever.
+// NOTE: TTL only expires data — it does NOT reduce the provisioned/autoscale RU bill.
+// Recovering the throughput cost requires decommissioning the container (or, if it must
+// stay, dropping it to the minimum RU/s).
+
+// 1. Optional retention: expire remaining data instead of holding it forever.
 var properties = await container.ReadContainerAsync();
 properties.Resource.DefaultTimeToLive = 60 * 60 * 24 * 30; // retain 30 days
 await container.ReplaceContainerAsync(properties.Resource);
 
-// After owner approval and a validated backup/export:
+// 2. After owner approval and a validated backup/export, delete it to stop paying:
 // await container.DeleteContainerAsync();
 ```
 
@@ -35,7 +39,7 @@ Safety gates before removing an idle container:
 1. Confirm the container is genuinely idle (no reads or writes over a representative window, not just low RU).
 2. Get owner approval and check retention/compliance requirements.
 3. Take and validate a backup or export.
-4. Prefer TTL or archival first; delete only after monitoring confirms nothing depends on it.
+4. TTL/archival control *data retention*, not throughput cost — to stop paying, delete the container (or lower its RU/s). Delete only after monitoring confirms nothing depends on it.
 
 This differs from `throughput-right-size`, which tunes an *active but oversized* container; here the container is effectively unused and the question is whether it should exist at all.
 

--- a/skills/cosmosdb-best-practices/rules/throughput-idle-container-review.md
+++ b/skills/cosmosdb-best-practices/rules/throughput-idle-container-review.md
@@ -7,7 +7,7 @@ tags: throughput, lifecycle, idle, ttl, decommission, cost
 
 ## Review Idle Containers for Lifecycle Action
 
-A container with near-zero traffic still bills for throughput: **manual** provisioning bills its full RU/s 24/7, and **autoscale** [bills each hour for the highest RU/s it scaled to that hour](https://learn.microsoft.com/azure/cosmos-db/provision-throughput-autoscale) (between 10% and 100% of the configured max) — so an idle autoscale container still bills the 10% minimum. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers that cost is **decommissioning the container** (or dropping it to the minimum RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
+A container on **dedicated (provisioned) throughput** still bills for that throughput at near-zero traffic: **manual** bills its full RU/s 24/7, and **autoscale** [bills each hour for the highest RU/s it scaled to that hour](https://learn.microsoft.com/azure/cosmos-db/provision-throughput-autoscale) (between 10% and 100% of the configured max) — so an idle autoscale container still bills the 10% minimum. (This rule targets that case. A **serverless** container bills per request, so idle costs nothing; a container on database-level **shared** throughput doesn't bill on its own — the RU/s belongs to the database.) Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers the cost is **decommissioning the container** (or dropping its RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
 
 **Incorrect (leaving an abandoned container provisioned):**
 
@@ -39,7 +39,7 @@ Safety gates before removing an idle container:
 1. Confirm the container is genuinely idle (no reads or writes over a representative window, not just low RU).
 2. Get owner approval and check retention/compliance requirements.
 3. Take and validate a backup or export.
-4. TTL/archival control *data retention*, not throughput cost — to stop paying, delete the container (or lower its RU/s). Delete only after monitoring confirms nothing depends on it.
+4. TTL/archival control *data retention*, not throughput cost. To recover **dedicated** throughput, delete the container (or lower its RU/s); on **shared** database throughput, deleting frees RU back to the database; **serverless** has no idle charge. Delete only after monitoring confirms nothing depends on it.
 
 This differs from `throughput-right-size`, which tunes an *active but oversized* container; here the container is effectively unused and the question is whether it should exist at all.
 

--- a/skills/cosmosdb-best-practices/rules/throughput-idle-container-review.md
+++ b/skills/cosmosdb-best-practices/rules/throughput-idle-container-review.md
@@ -7,7 +7,7 @@ tags: throughput, lifecycle, idle, ttl, decommission, cost
 
 ## Review Idle Containers for Lifecycle Action
 
-A container with near-zero traffic still carries its provisioned throughput — or an autoscale floor (10% of the configured max) — which is billed even while it sits idle. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers that cost is **decommissioning the container** (or dropping it to the minimum RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
+A container with near-zero traffic still bills for throughput: **manual** provisioning bills its full RU/s 24/7, and **autoscale** bills each hour for the highest RU/s it scaled to that hour (between 10% and 100% of the configured max) — so an idle autoscale container still bills the 10% minimum. Abandoned import staging, deprecated features, and one-off migrations commonly leave such containers behind. The lever that recovers that cost is **decommissioning the container** (or dropping it to the minimum RU/s if it must stay) — note that **TTL and archival reduce stored *data*, not the provisioned RU/s bill**. Before removing anything, confirm retention, compliance, and recovery requirements.
 
 **Incorrect (leaving an abandoned container provisioned):**
 
@@ -43,4 +43,6 @@ Safety gates before removing an idle container:
 
 This differs from `throughput-right-size`, which tunes an *active but oversized* container; here the container is effectively unused and the question is whether it should exist at all.
 
-Reference: [Time to Live (TTL) in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)
+References:
+- [Time to Live (TTL) in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/time-to-live)
+- [Provisioned throughput with autoscale (billing model)](https://learn.microsoft.com/azure/cosmos-db/provision-throughput-autoscale)


### PR DESCRIPTION
## New rule: `throughput-idle-container-review`

Adds `skills/cosmosdb-best-practices/rules/throughput-idle-container-review.md` (Throughput & Scaling / MEDIUM).

**Gap:** No existing rule covers safe decommission/TTL/archival review of a near-idle container (distinct from right-sizing an active one).

Follows `rules/_template.md` (frontmatter + Incorrect/Correct + reference); `npm run validate` passes for this rule. The generated `AGENTS.md` is left for maintainers to regenerate via `npm run build` to keep this diff to the single rule file.

_Draft - opened for review._