### PR TITLE
Add rule: global-multi-region-write-antipattern

### DIFF
--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -4270,7 +4270,7 @@ Capture and log diagnostics from Cosmos DB responses, especially for slow or fai
 
 `CosmosException.Diagnostics` (type `CosmosDiagnostics`) is a first-class structured signal the SDK provides for debugging failures (RU spend, latency tails, 429s, region selection, and channel reuse). Demonstrating the pattern is not enough — it must be applied at the point of failure.
 
-**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A catch block that swallows the exception (e.g., `catch (CosmosException) { }`, or returning `null` / `default` / `new T()`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
 
 **Incorrect (ignoring diagnostics):**
 
@@ -4428,7 +4428,7 @@ Key diagnostic fields:
 
 **Detector (mechanical check):** For each `catch` clause whose declared type binds to `Microsoft.Azure.Cosmos.CosmosException` (or a subclass), verify the block body contains a member access ending in `.Diagnostics` on the caught variable. If absent, flag the catch-block source range. This is expressible as a Roslyn analyzer or a regex over `.cs` files (excluding `bin/`, `obj/`, and test directories).
 
-**Why it matters:** `RequestCharge` and `ActivityId` provide immediate cost/correlation context, and `Diagnostics` provides the detailed timeline, regions contacted, and retry/transient-failure context (on a 429 it also includes retry details). Without diagnostics, the operator loses the detailed information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
+**Why it matters:** `Diagnostics` carries the RU charge, activity ID, the region the call hit, and the per-channel timing breakdown. On a 429 it also contains the back-end retry hints. Without it, the operator loses exactly the information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
 
 Reference: [Capture diagnostics — Troubleshoot .NET SDK](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk#capture-diagnostics)
 
@@ -9896,7 +9896,7 @@ Multi-region writes (multi-master) are valuable for true active-active write ava
 }
 ```
 
-**Correct (disable multi-region writes — the key change is `enableMultipleWriteLocations: false`; keep other regions as read replicas / failover if you want them):**
+**Correct (disable multi-region writes — the key change is `enableMultipleWriteLocations: false`; keep other regions as read replicas if you want them):**
 
 ```json
 {
@@ -9912,7 +9912,7 @@ Multi-region writes (multi-master) are valuable for true active-active write ava
 }
 ```
 
-The secondary region stays for reads and failover; only the *multi-write* capability is turned off. (For a dev account that needs just one region, you can also drop the extra location — but that is a separate decision from disabling multi-region writes.)
+The secondary region stays for reads (and, if `enableAutomaticFailover` is enabled on the account, as a failover target); only the *multi-write* capability is turned off. (For a dev account that needs just one region, you can also drop the extra location — but that is a separate decision from disabling multi-region writes.)
 
 When multi-region writes ARE justified (keep them enabled):
 - The application genuinely writes from multiple regions concurrently and needs local write latency.

--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -111,9 +111,10 @@ Performance optimization and best practices guide for Azure Cosmos DB applicatio
    - 7.1 [Implement Conflict Resolution](#71-implement-conflict-resolution)
    - 7.2 [Choose Appropriate Consistency Level](#72-choose-appropriate-consistency-level)
    - 7.3 [Configure Automatic Failover](#73-configure-automatic-failover)
-   - 7.4 [Configure Multi-Region Writes](#74-configure-multi-region-writes)
-   - 7.5 [Add Read Regions Near Users](#75-add-read-regions-near-users)
-   - 7.6 [Configure Zone Redundancy for High Availability](#76-configure-zone-redundancy-for-high-availability)
+   - 7.4 [Avoid Multi-Region Writes Without an Active-Active Need](#74-avoid-multi-region-writes-without-an-active-active-need)
+   - 7.5 [Configure Multi-Region Writes](#75-configure-multi-region-writes)
+   - 7.6 [Add Read Regions Near Users](#76-add-read-regions-near-users)
+   - 7.7 [Configure Zone Redundancy for High Availability](#77-configure-zone-redundancy-for-high-availability)
 8. [Monitoring & Diagnostics](#8-monitoring-diagnostics) — **LOW-MEDIUM**
    - 8.1 [Integrate Azure Monitor](#81-integrate-azure-monitor)
    - 8.2 [Enable Diagnostic Logging](#82-enable-diagnostic-logging)
@@ -4269,7 +4270,7 @@ Capture and log diagnostics from Cosmos DB responses, especially for slow or fai
 
 `CosmosException.Diagnostics` (type `CosmosDiagnostics`) is a first-class structured signal the SDK provides for debugging failures (RU spend, latency tails, 429s, region selection, and channel reuse). Demonstrating the pattern is not enough — it must be applied at the point of failure.
 
-**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A catch block that swallows the exception (e.g., `catch (CosmosException) { }`, or returning `null` / `default` / `new T()`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
 
 **Incorrect (ignoring diagnostics):**
 
@@ -4427,7 +4428,7 @@ Key diagnostic fields:
 
 **Detector (mechanical check):** For each `catch` clause whose declared type binds to `Microsoft.Azure.Cosmos.CosmosException` (or a subclass), verify the block body contains a member access ending in `.Diagnostics` on the caught variable. If absent, flag the catch-block source range. This is expressible as a Roslyn analyzer or a regex over `.cs` files (excluding `bin/`, `obj/`, and test directories).
 
-**Why it matters:** `Diagnostics` carries the RU charge, activity ID, the region the call hit, and the per-channel timing breakdown. On a 429 it also contains the back-end retry hints. Without it, the operator loses exactly the information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
+**Why it matters:** `RequestCharge` and `ActivityId` provide immediate cost/correlation context, and `Diagnostics` provides the detailed timeline, regions contacted, and retry/transient-failure context (on a 429 it also includes retry details). Without diagnostics, the operator loses the detailed information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
 
 Reference: [Capture diagnostics — Troubleshoot .NET SDK](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk#capture-diagnostics)
 
@@ -9871,7 +9872,57 @@ Automatic failover behavior:
 
 Reference: [Automatic failover](https://learn.microsoft.com/azure/cosmos-db/high-availability)
 
-### 7.4 Configure Multi-Region Writes
+### 7.4 Avoid Multi-Region Writes Without an Active-Active Need
+
+**Impact: MEDIUM** (removes conflict-resolution complexity and replicated write cost)
+
+## Avoid Multi-Region Writes Without an Active-Active Need
+
+Multi-region writes (multi-master) are valuable for true active-active write availability and very low RTO, but they add conflict-resolution complexity and can increase replicated write cost. Enabling them where they provide no benefit is an antipattern: non-production accounts that copy a production template, accounts where the workload only ever writes to one region, or a single-region account with the flag enabled as a latent tripwire. In these cases, disabling multi-region writes removes complexity and surprise cost with no loss of capability.
+
+**Incorrect (cloning production multi-write config into a dev account that writes to one region):**
+
+```json
+{
+  "type": "Microsoft.DocumentDB/databaseAccounts",
+  "name": "orders-dev",
+  "properties": {
+    "enableMultipleWriteLocations": true,
+    "locations": [
+      { "locationName": "West US 2", "failoverPriority": 0 },
+      { "locationName": "East US", "failoverPriority": 1 }
+    ]
+  }
+}
+```
+
+**Correct (disable multi-region writes — the key change is `enableMultipleWriteLocations: false`; keep other regions as read replicas / failover if you want them):**
+
+```json
+{
+  "type": "Microsoft.DocumentDB/databaseAccounts",
+  "name": "orders-dev",
+  "properties": {
+    "enableMultipleWriteLocations": false,
+    "locations": [
+      { "locationName": "West US 2", "failoverPriority": 0 },
+      { "locationName": "East US", "failoverPriority": 1 }
+    ]
+  }
+}
+```
+
+The secondary region stays for reads and failover; only the *multi-write* capability is turned off. (For a dev account that needs just one region, you can also drop the extra location — but that is a separate decision from disabling multi-region writes.)
+
+When multi-region writes ARE justified (keep them enabled):
+- The application genuinely writes from multiple regions concurrently and needs local write latency.
+- You require write availability during a regional outage (very low RTO) and have a conflict-resolution policy.
+
+If you enable multi-region writes for those reasons, pair them with a deliberate conflict-resolution strategy (see `global-conflict-resolution`). For the legitimate active-active pattern, see `global-multi-region`.
+
+Reference: [Configure multi-region writes](https://learn.microsoft.com/azure/cosmos-db/nosql/how-to-multi-master)
+
+### 7.5 Configure Multi-Region Writes
 
 **Impact: HIGH** (enables local writes, high availability)
 
@@ -9975,7 +10026,7 @@ Considerations:
 
 Reference: [Multi-region writes](https://learn.microsoft.com/azure/cosmos-db/multi-region-writes)
 
-### 7.5 Add Read Regions Near Users
+### 7.6 Add Read Regions Near Users
 
 **Impact: MEDIUM** (reduces read latency globally)
 
@@ -10108,7 +10159,7 @@ Cost considerations:
 
 Reference: [Global distribution](https://learn.microsoft.com/azure/cosmos-db/distribute-data-globally)
 
-### 7.6 Configure Zone Redundancy for High Availability
+### 7.7 Configure Zone Redundancy for High Availability
 
 **Impact: HIGH** (eliminates availability zone failures, increases SLA to 99.995%)
 

--- a/skills/cosmosdb-best-practices/SKILL.md
+++ b/skills/cosmosdb-best-practices/SKILL.md
@@ -154,6 +154,7 @@ Reference these guidelines when:
 - [global-failover](rules/global-failover.md) - Configure automatic failover
 - [global-read-regions](rules/global-read-regions.md) - Add read regions near users
 - [global-zone-redundancy](rules/global-zone-redundancy.md) - Enable zone redundancy for HA
+- [global-multi-region-write-antipattern](rules/global-multi-region-write-antipattern.md) - Avoid multi-region writes without an active-active need
 
 ### 8. Monitoring & Diagnostics (LOW-MEDIUM)
 

--- a/skills/cosmosdb-best-practices/rules/global-multi-region-write-antipattern.md
+++ b/skills/cosmosdb-best-practices/rules/global-multi-region-write-antipattern.md
@@ -7,7 +7,7 @@ tags: global, multi-region, write, antipattern, conflict, cost
 
 ## Avoid Multi-Region Writes Without an Active-Active Need
 
-Multi-region writes (multi-master) are valuable for true active-active write availability and RTO≈0, but they add conflict-resolution complexity and can increase replicated write cost. Enabling them where they provide no benefit is an antipattern: non-production accounts that copy a production template, accounts where the workload only ever writes to one region, or a single-region account with the flag enabled as a latent tripwire. In these cases, disabling multi-region writes removes complexity and surprise cost with no loss of capability.
+Multi-region writes (multi-master) are valuable for true active-active write availability and very low RTO, but they add conflict-resolution complexity and can increase replicated write cost. Enabling them where they provide no benefit is an antipattern: non-production accounts that copy a production template, accounts where the workload only ever writes to one region, or a single-region account with the flag enabled as a latent tripwire. In these cases, disabling multi-region writes removes complexity and surprise cost with no loss of capability.
 
 **Incorrect (cloning production multi-write config into a dev account that writes to one region):**
 
@@ -25,7 +25,7 @@ Multi-region writes (multi-master) are valuable for true active-active write ava
 }
 ```
 
-**Correct (single write region unless the workload truly needs active-active writes):**
+**Correct (disable multi-region writes — the key change is `enableMultipleWriteLocations: false`; keep other regions as read replicas / failover if you want them):**
 
 ```json
 {
@@ -34,15 +34,18 @@ Multi-region writes (multi-master) are valuable for true active-active write ava
   "properties": {
     "enableMultipleWriteLocations": false,
     "locations": [
-      { "locationName": "West US 2", "failoverPriority": 0 }
+      { "locationName": "West US 2", "failoverPriority": 0 },
+      { "locationName": "East US", "failoverPriority": 1 }
     ]
   }
 }
 ```
 
+The secondary region stays for reads and failover; only the *multi-write* capability is turned off. (For a dev account that needs just one region, you can also drop the extra location — but that is a separate decision from disabling multi-region writes.)
+
 When multi-region writes ARE justified (keep them enabled):
 - The application genuinely writes from multiple regions concurrently and needs local write latency.
-- You require write availability during a regional outage (RTO≈0) and have a conflict-resolution policy.
+- You require write availability during a regional outage (very low RTO) and have a conflict-resolution policy.
 
 If you enable multi-region writes for those reasons, pair them with a deliberate conflict-resolution strategy (see `global-conflict-resolution`). For the legitimate active-active pattern, see `global-multi-region`.
 

--- a/skills/cosmosdb-best-practices/rules/global-multi-region-write-antipattern.md
+++ b/skills/cosmosdb-best-practices/rules/global-multi-region-write-antipattern.md
@@ -1,0 +1,49 @@
+---
+title: Avoid Multi-Region Writes Without an Active-Active Need
+impact: MEDIUM
+impactDescription: removes conflict-resolution complexity and replicated write cost
+tags: global, multi-region, write, antipattern, conflict, cost
+---
+
+## Avoid Multi-Region Writes Without an Active-Active Need
+
+Multi-region writes (multi-master) are valuable for true active-active write availability and RTO≈0, but they add conflict-resolution complexity and can increase replicated write cost. Enabling them where they provide no benefit is an antipattern: non-production accounts that copy a production template, accounts where the workload only ever writes to one region, or a single-region account with the flag enabled as a latent tripwire. In these cases, disabling multi-region writes removes complexity and surprise cost with no loss of capability.
+
+**Incorrect (cloning production multi-write config into a dev account that writes to one region):**
+
+```json
+{
+  "type": "Microsoft.DocumentDB/databaseAccounts",
+  "name": "orders-dev",
+  "properties": {
+    "enableMultipleWriteLocations": true,
+    "locations": [
+      { "locationName": "West US 2", "failoverPriority": 0 },
+      { "locationName": "East US", "failoverPriority": 1 }
+    ]
+  }
+}
+```
+
+**Correct (single write region unless the workload truly needs active-active writes):**
+
+```json
+{
+  "type": "Microsoft.DocumentDB/databaseAccounts",
+  "name": "orders-dev",
+  "properties": {
+    "enableMultipleWriteLocations": false,
+    "locations": [
+      { "locationName": "West US 2", "failoverPriority": 0 }
+    ]
+  }
+}
+```
+
+When multi-region writes ARE justified (keep them enabled):
+- The application genuinely writes from multiple regions concurrently and needs local write latency.
+- You require write availability during a regional outage (RTO≈0) and have a conflict-resolution policy.
+
+If you enable multi-region writes for those reasons, pair them with a deliberate conflict-resolution strategy (see `global-conflict-resolution`). For the legitimate active-active pattern, see `global-multi-region`.
+
+Reference: [Configure multi-region writes](https://learn.microsoft.com/azure/cosmos-db/nosql/how-to-multi-master)

--- a/skills/cosmosdb-best-practices/rules/global-multi-region-write-antipattern.md
+++ b/skills/cosmosdb-best-practices/rules/global-multi-region-write-antipattern.md
@@ -25,7 +25,7 @@ Multi-region writes (multi-master) are valuable for true active-active write ava
 }
 ```
 
-**Correct (disable multi-region writes — the key change is `enableMultipleWriteLocations: false`; keep other regions as read replicas / failover if you want them):**
+**Correct (disable multi-region writes — the key change is `enableMultipleWriteLocations: false`; keep other regions as read replicas if you want them):**
 
 ```json
 {
@@ -41,7 +41,7 @@ Multi-region writes (multi-master) are valuable for true active-active write ava
 }
 ```
 
-The secondary region stays for reads and failover; only the *multi-write* capability is turned off. (For a dev account that needs just one region, you can also drop the extra location — but that is a separate decision from disabling multi-region writes.)
+The secondary region stays for reads (and, if `enableAutomaticFailover` is enabled on the account, as a failover target); only the *multi-write* capability is turned off. (For a dev account that needs just one region, you can also drop the extra location — but that is a separate decision from disabling multi-region writes.)
 
 When multi-region writes ARE justified (keep them enabled):
 - The application genuinely writes from multiple regions concurrently and needs local write latency.


### PR DESCRIPTION
## New rule: `global-multi-region-write-antipattern`

Adds `skills/cosmosdb-best-practices/rules/global-multi-region-write-antipattern.md` (Global Distribution / MEDIUM).

**Gap:** `global-multi-region` teaches when to ENABLE multi-region writes; nothing covers when to DISABLE them (non-prod, single write region, latent tripwire).

Follows `rules/_template.md` (frontmatter + Incorrect/Correct + reference); `npm run validate` passes for this rule. The generated `AGENTS.md` is left for maintainers to regenerate via `npm run build` to keep this diff to the single rule file.

_Draft - opened for review._