### PR TITLE
Add rule: throughput-serverless-migration

### DIFF
--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -106,7 +106,8 @@ Performance optimization and best practices guide for Azure Cosmos DB applicatio
    - 6.2 [Understand Burst Capacity](#62-understand-burst-capacity)
    - 6.3 [Choose Container vs Database Throughput](#63-choose-container-vs-database-throughput)
    - 6.4 [Right-Size Provisioned Throughput](#64-right-size-provisioned-throughput)
-   - 6.5 [Consider Serverless for Dev/Test](#65-consider-serverless-for-dev-test)
+   - 6.5 [Migrate a Low-Traffic Provisioned Account to Serverless](#65-migrate-a-low-traffic-provisioned-account-to-serverless)
+   - 6.6 [Consider Serverless for Dev/Test](#66-consider-serverless-for-dev-test)
 7. [Global Distribution](#7-global-distribution) — **MEDIUM**
    - 7.1 [Implement Conflict Resolution](#71-implement-conflict-resolution)
    - 7.2 [Choose Appropriate Consistency Level](#72-choose-appropriate-consistency-level)
@@ -4269,7 +4270,7 @@ Capture and log diagnostics from Cosmos DB responses, especially for slow or fai
 
 `CosmosException.Diagnostics` (type `CosmosDiagnostics`) is a first-class structured signal the SDK provides for debugging failures (RU spend, latency tails, 429s, region selection, and channel reuse). Demonstrating the pattern is not enough — it must be applied at the point of failure.
 
-**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A catch block that swallows the exception (e.g., `catch (CosmosException) { }`, or returning `null` / `default` / `new T()`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
 
 **Incorrect (ignoring diagnostics):**
 
@@ -4427,7 +4428,7 @@ Key diagnostic fields:
 
 **Detector (mechanical check):** For each `catch` clause whose declared type binds to `Microsoft.Azure.Cosmos.CosmosException` (or a subclass), verify the block body contains a member access ending in `.Diagnostics` on the caught variable. If absent, flag the catch-block source range. This is expressible as a Roslyn analyzer or a regex over `.cs` files (excluding `bin/`, `obj/`, and test directories).
 
-**Why it matters:** `Diagnostics` carries the RU charge, activity ID, the region the call hit, and the per-channel timing breakdown. On a 429 it also contains the back-end retry hints. Without it, the operator loses exactly the information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
+**Why it matters:** `RequestCharge` and `ActivityId` provide immediate cost/correlation context, and `Diagnostics` provides the detailed timeline, regions contacted, and retry/transient-failure context (on a 429 it also includes retry details). Without diagnostics, the operator loses the detailed information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
 
 Reference: [Capture diagnostics — Troubleshoot .NET SDK](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk#capture-diagnostics)
 
@@ -9411,7 +9412,60 @@ Throughput guidance:
 
 Reference: [Estimate RU/s](https://learn.microsoft.com/azure/cosmos-db/estimate-ru-with-capacity-planner)
 
-### 6.5 Consider Serverless for Dev/Test
+### 6.5 Migrate a Low-Traffic Provisioned Account to Serverless
+
+**Impact: MEDIUM** (pay-per-request pricing for sporadic workloads)
+
+## Migrate a Low-Traffic Provisioned Account to Serverless
+
+An account with low, sporadic consumption often costs less on serverless (pay-per-RU) than on always-on provisioned throughput, which bills its floor 24/7. Serverless is an account-level capacity mode, so switching a *provisioned* account to serverless is not an in-place toggle — you provision a new serverless account and copy the data, gated by hard feasibility constraints. Importantly, this is not a dead end: if the workload later outgrows serverless, the reverse direction (serverless → provisioned) **is** supported in-place.
+
+**Incorrect (leaving a low-traffic workload on always-on provisioned throughput):**
+
+```csharp
+// Provisioned account pays the 400 RU/s floor continuously even though the workload
+// is idle most of the day and never approaches that throughput.
+await database.CreateContainerIfNotExistsAsync(
+    new ContainerProperties("events", "/tenantId"),
+    throughput: 400);
+```
+
+**Correct (create a new serverless account, then migrate data into it):**
+
+```json
+// Serverless is an account-level capability set at creation (single region).
+{
+  "type": "Microsoft.DocumentDB/databaseAccounts",
+  "apiVersion": "2024-11-15",
+  "name": "events-serverless",
+  "properties": {
+    "databaseAccountOfferType": "Standard",
+    "capabilities": [ { "name": "EnableServerless" } ],
+    "locations": [ { "locationName": "West US 2", "failoverPriority": 0 } ]
+  }
+}
+```
+
+```csharp
+// Then copy data into the new account (change feed or bulk), cut over reads/writes,
+// and retire the old account. Container creation in serverless takes no throughput:
+await database.CreateContainerIfNotExistsAsync(
+    new ContainerProperties("events", "/tenantId"));
+```
+
+Verify these feasibility gates BEFORE migrating:
+- Single region only (serverless does not support multi-region distribution).
+- No database-level (shared) throughput — serverless is per-container consumption.
+- Sustained demand stays well under ~5,000 RU/s per physical partition.
+- A supported API (e.g., NoSQL).
+
+**If serverless is later outgrown:** you can change a serverless account to provisioned capacity **in-place** from the Azure portal (**Change capacity mode to provisioned throughput**). It converts every container to *manual* provisioned throughput (`RU/s = number of partitions × 5,000`), after which you can switch to autoscale. Note that this capacity-mode change is itself one-way — a provisioned account can't be changed back to serverless — so you would again need a new-account migration to return to serverless. For choosing serverless on a new (greenfield) project, see `throughput-serverless`.
+
+References:
+- [Serverless in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/serverless)
+- [Change from serverless to provisioned throughput](https://learn.microsoft.com/azure/cosmos-db/how-to-change-capacity-mode)
+
+### 6.6 Consider Serverless for Dev/Test
 
 **Impact: MEDIUM** (pay-per-request pricing)
 

--- a/skills/cosmosdb-best-practices/AGENTS.md
+++ b/skills/cosmosdb-best-practices/AGENTS.md
@@ -4270,7 +4270,7 @@ Capture and log diagnostics from Cosmos DB responses, especially for slow or fai
 
 `CosmosException.Diagnostics` (type `CosmosDiagnostics`) is a first-class structured signal the SDK provides for debugging failures (RU spend, latency tails, 429s, region selection, and channel reuse). Demonstrating the pattern is not enough — it must be applied at the point of failure.
 
-**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A catch block that swallows the exception (e.g., `catch (CosmosException) { }`, or returning `null` / `default` / `new T()`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
+**Required (strict syntactic minimum):** Every `catch` block whose declared exception type is `Microsoft.Azure.Cosmos.CosmosException` (or a subclass) **must reference `.Diagnostics` on the caught exception variable somewhere inside the catch-block body** — either by logging it as a structured field, or by attaching it to a re-thrown exception's message/data. A bare swallow (`catch (CosmosException) { }`, `catch (CosmosException) { return null; }`, `return default;`, `return new T();`, etc., without first surfacing `.Diagnostics`) is a violation unless the block first surfaces `.Diagnostics` (for example, by logging it before returning).
 
 **Incorrect (ignoring diagnostics):**
 
@@ -4428,7 +4428,7 @@ Key diagnostic fields:
 
 **Detector (mechanical check):** For each `catch` clause whose declared type binds to `Microsoft.Azure.Cosmos.CosmosException` (or a subclass), verify the block body contains a member access ending in `.Diagnostics` on the caught variable. If absent, flag the catch-block source range. This is expressible as a Roslyn analyzer or a regex over `.cs` files (excluding `bin/`, `obj/`, and test directories).
 
-**Why it matters:** `RequestCharge` and `ActivityId` provide immediate cost/correlation context, and `Diagnostics` provides the detailed timeline, regions contacted, and retry/transient-failure context (on a 429 it also includes retry details). Without diagnostics, the operator loses the detailed information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
+**Why it matters:** `Diagnostics` carries the RU charge, activity ID, the region the call hit, and the per-channel timing breakdown. On a 429 it also contains the back-end retry hints. Without it, the operator loses exactly the information needed to debug the failure. See the throughput / RU rules for why `RequestCharge` matters at observability time, and the retry / 429 handling guidance for why 429 catch blocks must capture diagnostics.
 
 Reference: [Capture diagnostics — Troubleshoot .NET SDK](https://learn.microsoft.com/azure/cosmos-db/nosql/troubleshoot-dotnet-sdk#capture-diagnostics)
 
@@ -9436,7 +9436,7 @@ await database.CreateContainerIfNotExistsAsync(
 // Serverless is an account-level capability set at creation (single region).
 {
   "type": "Microsoft.DocumentDB/databaseAccounts",
-  "apiVersion": "2024-11-15",
+  "apiVersion": "2021-10-15",
   "name": "events-serverless",
   "properties": {
     "databaseAccountOfferType": "Standard",

--- a/skills/cosmosdb-best-practices/SKILL.md
+++ b/skills/cosmosdb-best-practices/SKILL.md
@@ -145,6 +145,7 @@ Reference these guidelines when:
 - [throughput-serverless](rules/throughput-serverless.md) - Consider serverless for dev/test
 - [throughput-burst](rules/throughput-burst.md) - Understand burst capacity
 - [throughput-container-vs-database](rules/throughput-container-vs-database.md) - Choose allocation level wisely
+- [throughput-serverless-migration](rules/throughput-serverless-migration.md) - Migrate a low-traffic provisioned account to serverless
 
 ### 7. Global Distribution (MEDIUM)
 

--- a/skills/cosmosdb-best-practices/rules/throughput-serverless-migration.md
+++ b/skills/cosmosdb-best-practices/rules/throughput-serverless-migration.md
@@ -1,0 +1,55 @@
+---
+title: Migrate a Low-Traffic Provisioned Account to Serverless
+impact: MEDIUM
+impactDescription: pay-per-request pricing for sporadic workloads
+tags: throughput, serverless, migration, cost, irreversible
+---
+
+## Migrate a Low-Traffic Provisioned Account to Serverless
+
+An account with low, sporadic consumption often costs less on serverless (pay-per-RU) than on always-on provisioned throughput, which bills its floor 24/7. Serverless is an account-level capacity mode, so switching a *provisioned* account to serverless is not an in-place toggle — you provision a new serverless account and copy the data, gated by hard feasibility constraints. Importantly, this is not a dead end: if the workload later outgrows serverless, the reverse direction (serverless → provisioned) **is** supported in-place.
+
+**Incorrect (leaving a low-traffic workload on always-on provisioned throughput):**
+
+```csharp
+// Provisioned account pays the 400 RU/s floor continuously even though the workload
+// is idle most of the day and never approaches that throughput.
+await database.CreateContainerIfNotExistsAsync(
+    new ContainerProperties("events", "/tenantId"),
+    throughput: 400);
+```
+
+**Correct (create a new serverless account, then migrate data into it):**
+
+```json
+// Serverless is an account-level capability set at creation (single region).
+{
+  "type": "Microsoft.DocumentDB/databaseAccounts",
+  "apiVersion": "2024-11-15",
+  "name": "events-serverless",
+  "properties": {
+    "databaseAccountOfferType": "Standard",
+    "capabilities": [ { "name": "EnableServerless" } ],
+    "locations": [ { "locationName": "West US 2", "failoverPriority": 0 } ]
+  }
+}
+```
+
+```csharp
+// Then copy data into the new account (change feed or bulk), cut over reads/writes,
+// and retire the old account. Container creation in serverless takes no throughput:
+await database.CreateContainerIfNotExistsAsync(
+    new ContainerProperties("events", "/tenantId"));
+```
+
+Verify these feasibility gates BEFORE migrating:
+- Single region only (serverless does not support multi-region distribution).
+- No database-level (shared) throughput — serverless is per-container consumption.
+- Sustained demand stays well under ~5,000 RU/s per physical partition.
+- A supported API (e.g., NoSQL).
+
+**If serverless is later outgrown:** you can change a serverless account to provisioned capacity **in-place** from the Azure portal (**Change capacity mode to provisioned throughput**). It converts every container to *manual* provisioned throughput (`RU/s = number of partitions × 5,000`), after which you can switch to autoscale. Note that this capacity-mode change is itself one-way — a provisioned account can't be changed back to serverless — so you would again need a new-account migration to return to serverless. For choosing serverless on a new (greenfield) project, see `throughput-serverless`.
+
+References:
+- [Serverless in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/serverless)
+- [Change from serverless to provisioned throughput](https://learn.microsoft.com/azure/cosmos-db/how-to-change-capacity-mode)

--- a/skills/cosmosdb-best-practices/rules/throughput-serverless-migration.md
+++ b/skills/cosmosdb-best-practices/rules/throughput-serverless-migration.md
@@ -25,7 +25,7 @@ await database.CreateContainerIfNotExistsAsync(
 // Serverless is an account-level capability set at creation (single region).
 {
   "type": "Microsoft.DocumentDB/databaseAccounts",
-  "apiVersion": "2024-11-15",
+  "apiVersion": "2021-10-15",
   "name": "events-serverless",
   "properties": {
     "databaseAccountOfferType": "Standard",


### PR DESCRIPTION
## New rule: `throughput-serverless-migration`

Adds `skills/cosmosdb-best-practices/rules/throughput-serverless-migration.md` (Throughput & Scaling / MEDIUM).

**Gap:** `throughput-serverless` is greenfield dev/test and states multi-region is unsupported; it does not cover migrating an existing provisioned account, feasibility gates, or the one-way irreversibility.

Follows `rules/_template.md` (frontmatter + Incorrect/Correct + reference); `npm run validate` passes for this rule. The generated `AGENTS.md` is left for maintainers to regenerate via `npm run build` to keep this diff to the single rule file.

_Draft - opened for review._