### PR TITLE
Add Codex repo marketplace catalog

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "azure-cosmosdb",
+  "interface": {
+    "displayName": "Azure Cosmos DB"
+  },
+  "plugins": [
+    {
+      "name": "azure-cosmosdb",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Databases"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This is the high-level log. For detailed per-iteration evaluation notes (test re
 
 ---
 
+## 2026-07-21 — Add Codex repo marketplace catalog
+
+- **New catalog:** `.agents/plugins/marketplace.json` — Codex-native repo marketplace listing the `azure-cosmosdb` plugin (`source.path: "./"`, `category: "Databases"`), so users can add it with `codex plugin marketplace add AzureCosmosDB/cosmosdb-agent-kit`. Codex also reads the legacy `.claude-plugin/marketplace.json`. The catalog carries no package `version` (schema-only) and is intentionally excluded from `npm run version`.
+- **Docs:** README adds an OpenAI Codex CLI install section and updates the per-agent manifest table to reference both marketplace catalogs.
+
 ## v1.2.0 — 2026-07-21 — Add Kimi Code plugin surface
 
 - **New manifest:** `.kimi-plugin/plugin.json` — Official Kimi Code plugin for Azure Cosmos DB, bundling the skills (`./skills/`) and the Azure MCP server (`@azure/mcp`). Mirrors the Codex `interface` block (display name, category, default prompts, brand color).

--- a/README.md
+++ b/README.md
@@ -112,14 +112,24 @@ Or add the custom marketplace catalog, then install from the plugin manager (`/p
 
 The plugin manifest lives at `.kimi-plugin/plugin.json` and the catalog at `kimi-marketplace.json`.
 
+### OpenAI Codex CLI
+
+Add the repo marketplace, then install from the Plugins Directory in the ChatGPT desktop app:
+
+```
+codex plugin marketplace add AzureCosmosDB/cosmosdb-agent-kit
+```
+
+The plugin manifest lives at `.codex-plugin/plugin.json` and the marketplace catalog at `.agents/plugins/marketplace.json` (Codex also reads the legacy `.claude-plugin/marketplace.json`).
+
 ### Per-agent plugin directories
 
 The repository includes ready-made plugin manifests:
 
 | Agent | Manifest |
 |-------|----------|
-| Claude Code | `.claude-plugin/plugin.json` |
-| OpenAI Codex | `.codex-plugin/plugin.json` |
+| Claude Code | `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` |
+| OpenAI Codex | `.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json` |
 | Cursor | `.cursor-plugin/plugin.json` |
 | Gemini CLI | `gemini-extension.json` + `GEMINI.md` |
 | Kimi Code | `.kimi-plugin/plugin.json` |


### PR DESCRIPTION
Adds a Codex-native repo marketplace catalog so users can install the Azure Cosmos DB plugin via `codex plugin marketplace add AzureCosmosDB/cosmosdb-agent-kit`.

## Changes
- `.agents/plugins/marketplace.json` — Codex-native marketplace listing the `azure-cosmosdb` plugin (`source.path: ./`, `category: Databases`). Codex also reads the legacy `.claude-plugin/marketplace.json`.
- README: new OpenAI Codex CLI install section + updated per-agent manifest table.
- CHANGELOG: dated entry.

## Notes
- Docs/catalog-only; no manifest version bump. Manifest validator still passes at 1.2.0.
- `policy.authentication` set to `ON_INSTALL` (only value documented by Codex).