### PR TITLE
Fix over-blunt async verifier checks + run skill-efficacy eval on PRs via OIDC

### DIFF
--- a/.github/workflows/msbench-eval.yaml
+++ b/.github/workflows/msbench-eval.yaml
@@ -1,21 +1,30 @@
 name: SDK Skill-Efficacy Evaluation
 
-# Manually-triggered only (workflow_dispatch, no schedule). This pipeline
-# authenticates to Azure / the remote execution backend as the PERSON who triggers
-# the run, using an interactive device-code sign-in — the same identity the
-# evaluation harness authenticates you with when you run the eval locally.
-# No service principal is required for this path.
+# Triggered two ways:
+#   1. workflow_dispatch — run it manually from the Actions tab (optionally
+#      overriding the benchmark / repeat / threshold / model / baseline inputs).
+#   2. pull_request_target, label-gated — when a maintainer adds the `run-msbench`
+#      label to a PR (including PRs from forks), this evaluates the PR's version of
+#      the skill/benchmark. The label IS the security gate: pull_request_target runs
+#      in the BASE repo's context WITH secrets and the OIDC identity, so a maintainer
+#      must review the PR diff (especially scripts/, shared/ces/, and the dataset)
+#      BEFORE adding the label. Never label a PR whose runner/eval code is unreviewed.
 #
-# Whoever dispatches the workflow MUST:
-#   1. have an Azure account that is entitled to submit to the remote execution
-#      backend (and has read access to the internal Azure Artifacts feed), and
-#   2. watch this job's logs for the device-code prompt and complete the browser
-#      sign-in as that account within the timeout, otherwise the job fails.
+# Authentication is fully unattended via a user-assigned managed identity using
+# GitHub OIDC (federated credentials) — no device-code sign-in and no client secret.
+# azure/login@v2 exchanges the workflow's OIDC token for an Azure token, so every
+# later az / msbench-cli call runs as that identity. The identity must be entitled to
+# submit to the remote execution backend and have read access to the internal Azure
+# Artifacts feed. Required repo secrets:
+#   AZURE_CLIENT_ID        - client ID of the user-assigned managed identity
+#   AZURE_TENANT_ID        - its Entra tenant ID
+#   AZURE_SUBSCRIPTION_ID  - subscription to select after login
+# The managed identity needs a federated credential whose subject matches this repo's
+# pull_request (and/or branch) — see the identity's "Federated credentials" in Azure.
 #
-# To instead run this unattended/automated via a service principal (e.g. for a
-# scheduled run), see the "Set up a service principal for the evaluation
-# pipeline" tracking issue — that path needs extra permissions granted to the
-# SP first.
+# NOTE: pull_request_target always uses the workflow file from the DEFAULT branch, so
+# these trigger/auth changes only take effect once merged to main — the label will
+# not run this on the PR that introduces it.
 on:
   workflow_dispatch:
     inputs:
@@ -33,53 +42,63 @@ on:
         description: 'Copilot model (blank = runner default claude-sonnet-4.6)'
         required: false
         default: ''
-      tenant_id:
-        description: 'Azure tenant to sign into (blank = az default tenant)'
-        required: false
-        default: ''
       compare_baseline:
         description: 'Also run the skill-off baseline and report the efficacy delta (doubles run time)'
         type: boolean
         default: true
+  # Label-gated: a run is created only when the `run-msbench` label is added to a PR
+  # (the job-level `if` enforces the exact label name). Works for fork PRs too.
+  pull_request_target:
+    types: [labeled]
 
 permissions:
   contents: read
-  issues: write # Required if the evaluation fails and an issue must be created.
+  id-token: write   # Required for the OIDC token exchange in azure/login.
+  issues: write     # Required if the evaluation fails and an issue must be created.
+  pull-requests: read
+
+# One in-flight eval per PR (or per manual ref); a newer trigger cancels the older.
+concurrency:
+  group: msbench-eval-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   evaluate:
     name: Run skill-efficacy evaluation
     runs-on: ubuntu-latest
-    # Generous cap: interactive device-code sign-in (up to ~15 min) plus the run.
-    # Doubled to allow for the optional skill-off baseline pass (a second full run).
+    # Only run when dispatched manually, or when the `run-msbench` label is present
+    # on a PR (a maintainer's review of the diff is the security gate for the
+    # secrets/OIDC identity that pull_request_target exposes).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.label.name == 'run-msbench')
+    # Generous cap; doubled to allow the optional skill-off baseline pass.
     timeout-minutes: 120
 
     steps:
-      # Check out the repository so the evaluation and issue scripts are available.
+      # Check out the code to evaluate. For a labeled PR (including forks) check out
+      # the PR HEAD so the eval tests the PR's actual skill/benchmark changes — safe
+      # ONLY because the `run-msbench` label gate requires a maintainer to have
+      # reviewed the diff first. For workflow_dispatch these fall back to the repo/ref
+      # the run was started on. persist-credentials:false avoids leaving a token in
+      # the checked-out (potentially untrusted) working tree.
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
-      # Sign in to Azure interactively as the person who triggered this run. az prints
-      # a URL + one-time code to the logs; open it in a browser and authenticate as your
-      # evaluation-entitled account. The device-code flow polls for completion, so nothing
-      # needs to be typed back into the runner. All later az / msbench-cli calls in this
-      # job then run as that identity — which is how the evaluation harness authorizes
-      # the submission.
-      #
-      # Note: if your tenant's Conditional Access blocks device-code sign-in, use a
-      # self-hosted runner where you are already `az login`ed instead (see the SP issue
-      # for the fully-unattended alternative).
-      - name: Sign in to Azure (device code — triggerer's identity)
-        run: |
-          echo "=============================================================="
-          echo "Complete the device-code sign-in below as your evaluation-entitled"
-          echo "Azure account. The run waits until you finish (or it times out)."
-          echo "=============================================================="
-          if [ -n "${{ inputs.tenant_id }}" ]; then
-            az login --use-device-code --tenant "${{ inputs.tenant_id }}"
-          else
-            az login --use-device-code
-          fi
+      # Sign in to Azure unattended via the user-assigned managed identity using GitHub
+      # OIDC (federated credentials) — no client secret is stored. All later az /
+      # msbench-cli calls run as this identity, which authorizes the submission.
+      - name: Sign in to Azure (OIDC — managed identity)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       # Use Python 3.11 for the evaluation tooling and repository scripts.
       - name: Set up Python
@@ -121,6 +140,40 @@ jobs:
       # COSMOS is an optional Cosmos DB connection string secret. When configured, the script
       # forwards it (encrypted) so the verifier grades against a real Cosmos account instead of
       # the bundled emulator. Leave the secret unset to run against the emulator.
+      # Resolve run parameters. workflow_dispatch supplies them via inputs; a
+      # label-triggered PR run has no inputs, so fall back to sensible defaults
+      # (baseline on, so PR runs report the skill-on vs skill-off efficacy delta).
+      - name: Resolve run parameters
+        id: params
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IN_BENCHMARK: ${{ inputs.benchmark }}
+          IN_REPEAT: ${{ inputs.repeat }}
+          IN_THRESHOLD: ${{ inputs.threshold }}
+          IN_MODEL: ${{ inputs.model }}
+          IN_BASELINE: ${{ inputs.compare_baseline }}
+        run: |
+          BENCHMARK="${IN_BENCHMARK:-cosmos-sdk-skills}"
+          REPEAT="${IN_REPEAT:-3}"
+          THRESHOLD="${IN_THRESHOLD:-0.9}"
+          MODEL="${IN_MODEL:-}"
+          # Baseline defaults on; only a manual run that explicitly sets the input to
+          # "false" turns it off.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$IN_BASELINE" = "false" ]; then
+            BASELINE_FLAG=""
+          else
+            BASELINE_FLAG="--baseline"
+          fi
+          MODEL_FLAG=""
+          [ -n "$MODEL" ] && MODEL_FLAG="--model $MODEL"
+          {
+            echo "benchmark=$BENCHMARK"
+            echo "repeat=$REPEAT"
+            echo "threshold=$THRESHOLD"
+            echo "model_flag=$MODEL_FLAG"
+            echo "baseline_flag=$BASELINE_FLAG"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Run skill-efficacy evaluation
         env:
           GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
@@ -132,11 +185,11 @@ jobs:
           MSBENCH_RUN_ANALYSIS_URL: ${{ vars.MSBENCH_RUN_ANALYSIS_URL }}
         run: |
           python scripts/msbench-eval.py \
-            --benchmark "${{ inputs.benchmark }}" \
-            --repeat "${{ inputs.repeat }}" \
-            --threshold "${{ inputs.threshold }}" \
-            ${{ inputs.model && format('--model {0}', inputs.model) || '' }} \
-            ${{ inputs.compare_baseline && '--baseline' || '' }} \
+            --benchmark "${{ steps.params.outputs.benchmark }}" \
+            --repeat "${{ steps.params.outputs.repeat }}" \
+            --threshold "${{ steps.params.outputs.threshold }}" \
+            ${{ steps.params.outputs.model_flag }} \
+            ${{ steps.params.outputs.baseline_flag }} \
             --output results.json
 
       # If the evaluation step fails and a results file was produced, create a GitHub issue

--- a/.github/workflows/msbench-eval.yaml
+++ b/.github/workflows/msbench-eval.yaml
@@ -35,8 +35,14 @@ name: SDK Skill-Efficacy Evaluation
 #   AZURE_CLIENT_ID        - client ID of the user-assigned managed identity
 #   AZURE_TENANT_ID        - its Entra tenant ID
 #   AZURE_SUBSCRIPTION_ID  - subscription to select after login
-# The managed identity needs a federated credential whose subject matches this repo's
-# pull_request (and/or branch) — see the identity's "Federated credentials" in Azure.
+# The managed identity needs a federated credential whose subject is this repo's
+# `msbench-eval` environment. Because the evaluate job references that environment,
+# GitHub sets the OIDC token subject to
+#   repo:AzureCosmosDB/cosmosdb-agent-kit:environment:msbench-eval
+# (the environment format takes precedence over pull_request/branch). So the credential
+# MUST use Entity type "Environment" with name `msbench-eval` — a pull_request/branch
+# subject will NOT match and azure/login will fail. See the identity's "Federated
+# credentials" in Azure.
 #
 # NOTE: pull_request_target always uses the workflow file from the DEFAULT branch, so
 # these trigger/auth changes only take effect once merged to main — the label will

--- a/.github/workflows/msbench-eval.yaml
+++ b/.github/workflows/msbench-eval.yaml
@@ -5,10 +5,26 @@ name: SDK Skill-Efficacy Evaluation
 #      overriding the benchmark / repeat / threshold / model / baseline inputs).
 #   2. pull_request_target, label-gated — when a maintainer adds the `run-msbench`
 #      label to a PR (including PRs from forks), this evaluates the PR's version of
-#      the skill/benchmark. The label IS the security gate: pull_request_target runs
-#      in the BASE repo's context WITH secrets and the OIDC identity, so a maintainer
-#      must review the PR diff (especially scripts/, shared/ces/, and the dataset)
-#      BEFORE adding the label. Never label a PR whose runner/eval code is unreviewed.
+#      the skill/benchmark. A labeled PR also re-evaluates on every new push
+#      (`synchronize`), so the eval always reflects the latest commit.
+#
+# SECURITY BOUNDARY: the label is only a convenience trigger — it is NOT the security
+# gate. pull_request_target runs in the BASE repo's context WITH secrets and the OIDC
+# identity and checks out PR HEAD, so the real gate is the `msbench-eval` deployment
+# environment referenced by the job: it has REQUIRED REVIEWERS, so every run pauses
+# until an authorized reviewer approves it, with a per-run audit trail — independent of
+# who can apply the label (triage can label, but cannot approve the run). Reviewers must
+# inspect the PR diff (especially scripts/, shared/ces/, and the dataset) before
+# approving, since checked-out PR code effectively runs as the managed identity.
+#
+# REPO CONFIG REQUIRED (one-time, in Settings):
+#   - Create an Environment named `msbench-eval` with one or more Required reviewers.
+#   - Recommended (defense-in-depth): scope the run secrets (COPILOT_GITHUB_TOKEN,
+#     AZURE_CLIENT_ID/TENANT_ID/SUBSCRIPTION_ID, COSMOS) to that environment so they
+#     are only exposed after a reviewer approves.
+#   - Keep the managed identity least-privilege: grant it ONLY the roles it needs
+#     (submit to the CES backend + read the internal Artifacts feed), never a
+#     subscription-wide Contributor/Owner role — checked-out PR code runs as it.
 #
 # Authentication is fully unattended via a user-assigned managed identity using
 # GitHub OIDC (federated credentials) — no device-code sign-in and no client secret.
@@ -46,16 +62,17 @@ on:
         description: 'Also run the skill-off baseline and report the efficacy delta (doubles run time)'
         type: boolean
         default: true
-  # Label-gated: a run is created only when the `run-msbench` label is added to a PR
-  # (the job-level `if` enforces the exact label name). Works for fork PRs too.
+  # Label-gated: a run is created when the `run-msbench` label is present on a PR, and
+  # re-created on every subsequent push (`synchronize`) while the label remains. The
+  # job-level `if` enforces the exact label name. The `msbench-eval` environment (with
+  # required reviewers) is what actually authorizes each run. Works for fork PRs too.
   pull_request_target:
-    types: [labeled]
+    types: [labeled, synchronize]
 
 permissions:
   contents: read
   id-token: write   # Required for the OIDC token exchange in azure/login.
   issues: write     # Required if the evaluation fails and an issue must be created.
-  pull-requests: read
 
 # One in-flight eval per PR (or per manual ref); a newer trigger cancels the older.
 concurrency:
@@ -66,23 +83,28 @@ jobs:
   evaluate:
     name: Run skill-efficacy evaluation
     runs-on: ubuntu-latest
-    # Only run when dispatched manually, or when the `run-msbench` label is present
-    # on a PR (a maintainer's review of the diff is the security gate for the
-    # secrets/OIDC identity that pull_request_target exposes).
+    # The security gate: this environment must have required reviewers, so every run
+    # (including fork PRs) pauses until an authorized reviewer approves it — with a
+    # per-run audit trail, independent of who applied the `run-msbench` label.
+    environment: msbench-eval
+    # Run when dispatched manually, or when a PR carries the `run-msbench` label. The
+    # labels-array check (not github.event.label) covers BOTH the `labeled` event and
+    # `synchronize` pushes on an already-labeled PR, so the eval re-runs on new commits.
+    # This only gates job creation; the `msbench-eval` environment enforces approval.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' &&
-       github.event.label.name == 'run-msbench')
+       contains(github.event.pull_request.labels.*.name, 'run-msbench'))
     # Generous cap; doubled to allow the optional skill-off baseline pass.
     timeout-minutes: 120
 
     steps:
       # Check out the code to evaluate. For a labeled PR (including forks) check out
       # the PR HEAD so the eval tests the PR's actual skill/benchmark changes — safe
-      # ONLY because the `run-msbench` label gate requires a maintainer to have
-      # reviewed the diff first. For workflow_dispatch these fall back to the repo/ref
-      # the run was started on. persist-credentials:false avoids leaving a token in
-      # the checked-out (potentially untrusted) working tree.
+      # ONLY because the `msbench-eval` environment requires a reviewer to approve the
+      # run (after inspecting the diff) before this executes. For workflow_dispatch these
+      # fall back to the repo/ref the run was started on. persist-credentials:false avoids
+      # leaving a token in the checked-out (potentially untrusted) working tree.
       - name: Check out repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/msbench-eval.yaml
+++ b/.github/workflows/msbench-eval.yaml
@@ -3,7 +3,7 @@ name: SDK Skill-Efficacy Evaluation
 # Triggered two ways:
 #   1. workflow_dispatch — run it manually from the Actions tab (optionally
 #      overriding the benchmark / repeat / threshold / model / baseline inputs).
-#   2. pull_request_target, label-gated — when a maintainer adds the `run-msbench`
+#   2. pull_request_target, label-gated — when a maintainer adds the `run-skill-eval`
 #      label to a PR (including PRs from forks), this evaluates the PR's version of
 #      the skill/benchmark. A labeled PR also re-evaluates on every new push
 #      (`synchronize`), so the eval always reflects the latest commit.
@@ -68,7 +68,7 @@ on:
         description: 'Also run the skill-off baseline and report the efficacy delta (doubles run time)'
         type: boolean
         default: true
-  # Label-gated: a run is created when the `run-msbench` label is present on a PR, and
+  # Label-gated: a run is created when the `run-skill-eval` label is present on a PR, and
   # re-created on every subsequent push (`synchronize`) while the label remains. The
   # job-level `if` enforces the exact label name. The `msbench-eval` environment (with
   # required reviewers) is what actually authorizes each run. Works for fork PRs too.
@@ -91,16 +91,16 @@ jobs:
     runs-on: ubuntu-latest
     # The security gate: this environment must have required reviewers, so every run
     # (including fork PRs) pauses until an authorized reviewer approves it — with a
-    # per-run audit trail, independent of who applied the `run-msbench` label.
+    # per-run audit trail, independent of who applied the `run-skill-eval` label.
     environment: msbench-eval
-    # Run when dispatched manually, or when a PR carries the `run-msbench` label. The
+    # Run when dispatched manually, or when a PR carries the `run-skill-eval` label. The
     # labels-array check (not github.event.label) covers BOTH the `labeled` event and
     # `synchronize` pushes on an already-labeled PR, so the eval re-runs on new commits.
     # This only gates job creation; the `msbench-eval` environment enforces approval.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' &&
-       contains(github.event.pull_request.labels.*.name, 'run-msbench'))
+       contains(github.event.pull_request.labels.*.name, 'run-skill-eval'))
     # Generous cap; doubled to allow the optional skill-off baseline pass.
     timeout-minutes: 120
 

--- a/benchmarks/cosmos-sdk-skills/shared/verifier/check_skills.py
+++ b/benchmarks/cosmos-sdk-skills/shared/verifier/check_skills.py
@@ -98,34 +98,24 @@ class TestDotnetForbiddenPackage:
 # Python: async client required inside async web frameworks
 # ---------------------------------------------------------------------
 
-# Frameworks whose presence implies an asyncio event loop is running.
-_PY_ASYNC_FRAMEWORKS = [
-    "fastapi", "FastAPI",
-    "from quart", "import quart",
-    "from sanic", "import sanic",
-    "starlette.applications",
-    "azure.functions.AsyncApp",
-    "langgraph.",
-]
-
-
 class TestPythonAsyncClient:
     """Rule sdk-python-async-deps: keep async Cosmos usage consistent.
-    If the source imports an async web framework, at least one route
-    handler must be `async def`, and if the async client
-    (azure.cosmos.aio) is used then `aiohttp` must be pinned as a
-    dependency."""
+    These checks are gated on the async Cosmos client (azure.cosmos.aio)
+    actually being used -- an app that pairs an async web framework with
+    the sync client and plain `def` handlers is acceptable (the handlers
+    run in a threadpool), so framework presence alone is never flagged.
+    When the aio client is used, at least one route handler must be
+    `async def`, and `aiohttp` must be pinned as a dependency."""
 
     def test_at_least_one_async_handler(self, sdk, source_text):
         _need(sdk, "python")
-        is_async_app = any(marker in source_text for marker in _PY_ASYNC_FRAMEWORKS)
-        if not is_async_app:
-            pytest.skip("No async web framework detected.")
+        if "azure.cosmos.aio" not in source_text:
+            pytest.skip("Async Cosmos client not in use; sync client with `def` handlers is acceptable.")
         assert re.search(r"async\s+def\s+\w+\s*\(", source_text), (
-            "No `async def` handler found. With the async Cosmos client, every "
-            "handler that touches Cosmos must be `async def` and `await` the call. "
-            "Plain `def` handlers force FastAPI to run them in a threadpool, which "
-            "negates the point of the async client."
+            "The async Cosmos client (azure.cosmos.aio) is in use but no `async def` "
+            "handler was found. Every handler that awaits a Cosmos call must be "
+            "`async def`; calling the aio client from plain `def` handlers means the "
+            "coroutines are never awaited on the event loop. Rule sdk-python-async-deps."
         )
 
     def test_aiohttp_dependency_pinned(self, sdk, source_text):

--- a/benchmarks/cosmos-sdk-skills/shared/verifier/check_skills.py
+++ b/benchmarks/cosmos-sdk-skills/shared/verifier/check_skills.py
@@ -110,23 +110,11 @@ _PY_ASYNC_FRAMEWORKS = [
 
 
 class TestPythonAsyncClient:
-    """Rule sdk-python-async-deps: don't run the sync Cosmos client
-    inside an asyncio event loop. If the source imports an async web
-    framework, the Cosmos client must come from azure.cosmos.aio and
-    at least one route handler must be `async def`."""
-
-    def test_async_client_when_async_framework_present(self, sdk, source_text):
-        _need(sdk, "python")
-        is_async_app = any(marker in source_text for marker in _PY_ASYNC_FRAMEWORKS)
-        if not is_async_app:
-            pytest.skip("No async web framework detected; sync client is acceptable.")
-        assert "azure.cosmos.aio" in source_text, (
-            "Detected an async web framework (FastAPI / Quart / Sanic / Starlette / "
-            "Azure Functions async / LangGraph) but the Cosmos client is the sync "
-            "`azure.cosmos.CosmosClient`. Rule sdk-python-async-deps: switch to "
-            "`from azure.cosmos.aio import CosmosClient` (and pin `aiohttp` in "
-            "requirements.txt). The sync client blocks the event loop and can deadlock."
-        )
+    """Rule sdk-python-async-deps: keep async Cosmos usage consistent.
+    If the source imports an async web framework, at least one route
+    handler must be `async def`, and if the async client
+    (azure.cosmos.aio) is used then `aiohttp` must be pinned as a
+    dependency."""
 
     def test_at_least_one_async_handler(self, sdk, source_text):
         _need(sdk, "python")


### PR DESCRIPTION
This PR bundles two related verifier fixes with the CI-auth change that lets the skill-efficacy eval run on PRs.

## 1. Verifier: stop over-flagging sync Cosmos clients in async apps

`benchmarks/cosmos-sdk-skills/shared/verifier/check_skills.py`

**Removed** `TestPythonAsyncClient.test_async_client_when_async_framework_present`. It statically failed **any** Python app that paired an async web framework (FastAPI/Quart/Sanic/Starlette/async Azure Functions/LangGraph) with the sync `azure.cosmos.CosmosClient`. That over-flags:

- **The app works.** FastAPI runs sync `def` handlers in a threadpool, so a sync client there does **not** block the event loop. In 5 mosaic-python runs the apps ran fine — 37/38 tests passed, with only this static check failing.
- **It only greps for `azure.cosmos.aio`.** It cannot distinguish a genuinely bad pattern (sync client inside an `async def` handler) from a fine one (sync client inside a sync `def` handler).
- **It misattributes the failure.** The assertion cites rule `sdk-python-async-deps`, but that rule only governs pinning `aiohttp` *when the aio client is used* — not client selection. No documented rule mandates the aio client purely from framework presence.

**Fixed** the sibling `test_at_least_one_async_handler`, which had the same flaw — it fired on async-framework detection alone, so a FastAPI app that intentionally used the sync client with `def` handlers still failed. It now skips unless `azure.cosmos.aio` is actually imported, and the message no longer implies the async client is in use when it isn't. Dropped the now-unused `_PY_ASYNC_FRAMEWORKS` marker list.

**Retained** `test_aiohttp_dependency_pinned` (maps to the actual documented rule) and updated the class docstring to match what remains.

Client-selection under concurrency is a real **scale/quality** concern, but it's better measured with an at-scale experiment than gated as a `reward=0` correctness failure on a single-request functional run.

## 2. CI: run the eval on PRs via OIDC managed identity

`.github/workflows/msbench-eval.yaml`

- **Unattended auth.** Replaces the interactive device-code `az login` with GitHub OIDC federated login to a user-assigned managed identity (`azure/login@v2` + `id-token: write`), using the `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` repo secrets. No client secret is stored.
- **Required-reviewer environment gate.** The `evaluate` job runs in a `msbench-eval` deployment environment with **required reviewers**, so every `pull_request_target` run (including forks) pauses until an authorized reviewer approves it — with a per-run audit trail, independent of who applied the `run-skill-eval` label. Reviewers inspect the diff before approving, since checked-out PR head runs as the managed identity. The job checks out PR head with `persist-credentials: false`.
- **Label + push trigger.** `pull_request_target: types: [labeled, synchronize]` plus a labels-array `if` check: adding the `run-skill-eval` label starts an eval, and a labeled PR **re-evaluates on every new push** (each run still gated by the environment approval). The label is only a trigger now — not the security boundary.
- **Least-privilege.** Drops the unused `pull-requests: read` token permission.
- Adds a Resolve-parameters step (PR runs have no `workflow_dispatch` inputs, so it supplies defaults — baseline on), a per-PR concurrency group, and drops the now-unused `tenant_id` input.

### Operational notes for reviewers/maintainers

- Because `pull_request_target` always uses the workflow from the **default branch**, this takes effect only **after** merge — it won't run on this PR itself.
- **Create the `msbench-eval` environment** (Settings → Environments) with one or more **required reviewers** before enabling PR runs — without it the gate does not exist. Recommended: scope the run secrets (`COPILOT_GITHUB_TOKEN`, `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID`, `COSMOS`) to that environment so they are only exposed after approval.
- Keep the managed identity **least-privilege**: it should hold only the roles it needs (submit to the CES backend + read the internal Artifacts feed), never a subscription-wide Contributor/Owner role — checked-out PR code runs as it.
- The `run-skill-eval` label must exist in the repo before it can be applied.
- The managed identity's federated credential subject must match a `pull_request_target` run (base branch), i.e. `repo:AzureCosmosDB/cosmosdb-agent-kit:ref:refs/heads/main` — **not** `:pull_request`.

## Verification

- **Static checks.** `python -m py_compile` passes on the verifier; the workflow YAML parses.
- **Verifier fix — locally.** Ran the two sibling checks against synthetic sync/async apps: the pre-fix checks false-positived a **valid** sync-client + FastAPI `def`-handler app, while the fix still fails a genuinely bad aio-client-from-`def`-handler app. Also ran a full end-to-end mosaic-python MSBench A/B on the local Docker (emulator) backend — 2 attempts **with** the removed check and 2 **without**. The removed check fired only on the sync-client + async-framework pattern and never changed a reward on its own (reward is binary and those apps failed on unrelated checks), confirming it produced false positives while adding no isolated signal.
- **CES backend.** The eval harness, runner, grading, and OIDC/auth submission path were exercised against the CES backend to confirm the pipeline works end-to-end outside the local emulator.

