### PR TITLE
Improve vector index selection guidance

### DIFF
--- a/evals/cosmosdb-best-practices/tasks/vector-index-type.yaml
+++ b/evals/cosmosdb-best-practices/tasks/vector-index-type.yaml
@@ -1,0 +1,30 @@
+id: vector-index-type-013
+name: Vector Search - Select Index Type by Query Scope
+description: |
+  Test that the skill selects flat, quantizedFlat, and diskANN from exactness,
+  dimensions, and query-scoped vector counts; distinguishes the 1,000-vector
+  activation threshold; and recommends regular-index exclusion and recall tuning.
+tags:
+  - vector
+  - indexing
+  - decision
+inputs:
+  prompt: |
+    Choose an Azure Cosmos DB for NoSQL vector index for each workload and
+    explain the decision criteria:
+
+    1. A compliance search uses 384-dimensional embeddings, must return the
+       exact top results, and searches about 8,000 vectors after its tenant filter.
+    2. A product container holds 1.2 million 1,536-dimensional vectors, but its
+       partition key and category filter leave about 35,000 candidates per query.
+       A small loss from vector compression is acceptable.
+    3. A catalog search uses 1,536-dimensional vectors and important queries span
+       roughly 4 million candidates. Low latency and RU usage matter more than
+       exact, deterministic top-K results.
+
+    Development starts with only 600 indexed vectors before production ingestion.
+    Also explain how to configure the embedding path in the regular indexing
+    policy and how to improve recall for workload 3 if its first results are low.
+expected:
+  outcomes:
+    - type: task_completed

--- a/skills/cosmosdb-best-practices/rules/vector-index-type.md
+++ b/skills/cosmosdb-best-practices/rules/vector-index-type.md
@@ -12,11 +12,11 @@ tags: vector, index, flat, quantizedflat, diskann, performance
 Vector indexes must be added to the indexing policy to enable efficient vector similarity search. Choose an index from the required recall, vector dimensions, and number of vectors scoped to each important query after partition-key and filter predicates. Do not choose from the total container size alone.
 
 **Vector Index Types:**
-- `flat`: Exact brute-force search with 100% recall. Use for exact search over small, focused candidate sets when vectors have at most 505 dimensions.
+- `flat`: Exact brute-force search with 100% recall. Use for exact search over small, focused candidate sets subject to the documented [505-dimension service limit](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search#vector-indexing-policies).
 - `quantizedFlat`: Brute-force search over compressed vectors. It supports up to 4,096 dimensions and is a good starting point when filters or partition scope leave 50,000 or fewer vectors per search. Quantization can introduce a small loss of accuracy.
 - `diskANN`: Approximate nearest-neighbor search that supports up to 4,096 dimensions. It generally provides the best latency, throughput, and RU efficiency when important queries span more than 50,000 vectors, but it doesn't guarantee exact or deterministic top-K results.
 
-`quantizedFlat` and `diskANN` require at least 1,000 indexed vectors before Cosmos DB uses the vector index. With fewer vectors, the query uses a full scan. This activation threshold is separate from the 50,000-vector selection guideline, which applies to the candidate set scoped to an individual search.
+`quantizedFlat` and `diskANN` [require at least 1,000 indexed vectors](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search#vector-indexing-policies) before Cosmos DB uses the vector index. With fewer vectors, the query uses a full scan. This activation threshold is separate from the 50,000-vector selection guideline, which applies to the candidate set scoped to an individual search.
 
 **CRITICAL: Exclude vector paths from regular indexing** to avoid high RU charges and latency on inserts.
 
@@ -137,7 +137,7 @@ database.createContainer(containerProperties).block();
 ```
 
 **Index Type Selection Workflow:**
-1. If the workload requires exact top-K results, use `flat` when the vectors have at most 505 dimensions and the scoped candidate set is small enough for the workload's latency and RU targets.
+1. If the workload requires exact top-K results, use `flat` when the vectors satisfy the `flat` dimension limit above and the scoped candidate set is small enough for the workload's latency and RU targets.
 2. If compressed or approximate results are acceptable, estimate the vectors remaining after the partition key and filters used by each important query:
     - Start with `quantizedFlat` when the scoped search has 50,000 or fewer vectors.
     - Start with `diskANN` when the scoped search has more than 50,000 vectors.

--- a/skills/cosmosdb-best-practices/rules/vector-index-type.md
+++ b/skills/cosmosdb-best-practices/rules/vector-index-type.md
@@ -2,18 +2,21 @@
 title: Configure Vector Indexes in Indexing Policy
 impact: CRITICAL
 impactDescription: Required for vector search performance
-tags: vector, index, quantizedflat, diskann, performance
+tags: vector, index, flat, quantizedflat, diskann, performance
 ---
 
 ## Configure Vector Indexes in Indexing Policy
 
 **Impact: CRITICAL (Required for vector search performance)**
 
-Vector indexes must be added to the indexing policy to enable efficient vector similarity search. Choose between QuantizedFlat (faster builds, good for smaller datasets) or DiskANN (better for larger datasets, requires more memory).
+Vector indexes must be added to the indexing policy to enable efficient vector similarity search. Choose an index from the required recall, vector dimensions, and number of vectors scoped to each important query after partition-key and filter predicates. Do not choose from the total container size alone.
 
 **Vector Index Types:**
-- `QuantizedFlat`: Quantized flat index - faster to build, good for datasets < 50K vectors
-- `DiskANN`: Disk-based approximate nearest neighbor - better for larger datasets, optimized for scale
+- `flat`: Exact brute-force search with 100% recall. Use for exact search over small, focused candidate sets when vectors have at most 505 dimensions.
+- `quantizedFlat`: Brute-force search over compressed vectors. It supports up to 4,096 dimensions and is a good starting point when filters or partition scope leave 50,000 or fewer vectors per search. Quantization can introduce a small loss of accuracy.
+- `diskANN`: Approximate nearest-neighbor search that supports up to 4,096 dimensions. It generally provides the best latency, throughput, and RU efficiency when important queries span more than 50,000 vectors, but it doesn't guarantee exact or deterministic top-K results.
+
+`quantizedFlat` and `diskANN` require at least 1,000 indexed vectors before Cosmos DB uses the vector index. With fewer vectors, the query uses a full scan. This activation threshold is separate from the 50,000-vector selection guideline, which applies to the candidate set scoped to an individual search.
 
 **CRITICAL: Exclude vector paths from regular indexing** to avoid high RU charges and latency on inserts.
 
@@ -77,7 +80,7 @@ indexing_policy = {
     "vectorIndexes": [
         {
             "path": "/embedding", 
-            "type": "quantizedFlat"  # or "diskANN" for larger datasets
+            "type": "quantizedFlat"  # or "diskANN" for broader query scopes
         }
     ] 
 }
@@ -133,8 +136,13 @@ containerProperties.setIndexingPolicy(indexingPolicy);
 database.createContainer(containerProperties).block();
 ```
 
-**Index Type Selection Guide:**
-- Use `QuantizedFlat` for: < 50K vectors, faster builds, lower memory
-- Use `DiskANN` for: > 50K vectors, better recall, production workloads
+**Index Type Selection Workflow:**
+1. If the workload requires exact top-K results, use `flat` when the vectors have at most 505 dimensions and the scoped candidate set is small enough for the workload's latency and RU targets.
+2. If compressed or approximate results are acceptable, estimate the vectors remaining after the partition key and filters used by each important query:
+    - Start with `quantizedFlat` when the scoped search has 50,000 or fewer vectors.
+    - Start with `diskANN` when the scoped search has more than 50,000 vectors.
+3. Test the choice with representative embeddings from the production model. Random vectors don't reproduce the geometry or recall behavior of real embeddings.
+4. Measure recall, latency, throughput, and RU consumption instead of treating 50,000 as a hard cutoff. For `diskANN`, increase `searchListSizeMultiplier` in `VectorDistance` when higher recall is worth additional latency and RU cost.
+5. Keep the vector path in `vectorIndexes` and exclude it from the regular index regardless of the selected vector index type.
 
-Reference: [.NET](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-dotnet-vector-index-query#create-a-vector-index-in-the-indexing-policy) | [Python](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-python-vector-index-query#create-a-vector-index-in-the-indexing-policy) | [JavaScript](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-javascript-vector-index-query#create-a-vector-index-in-the-indexing-policy) | [Java](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-java-vector-index-query#create-a-vector-index-in-the-indexing-policy)
+Reference: [Vector indexing policies](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search#vector-indexing-policies) | [.NET](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-dotnet-vector-index-query#create-a-vector-index-in-the-indexing-policy) | [Python](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-python-vector-index-query#create-a-vector-index-in-the-indexing-policy) | [JavaScript](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-javascript-vector-index-query#create-a-vector-index-in-the-indexing-policy) | [Java](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-java-vector-index-query#create-a-vector-index-in-the-indexing-policy)


### PR DESCRIPTION
## Description

Improve the existing vector index rule so index selection follows workload requirements instead of total container size alone.

- Document `flat`, `quantizedFlat`, and `diskANN` recall and dimensionality tradeoffs.
- Base the 50,000-vector guideline on the candidate set remaining after partition-key and filter scope.
- Distinguish that guideline from the 1,000 indexed-vector activation threshold for `quantizedFlat` and `diskANN`.
- Add guidance for representative-embedding benchmarks and DiskANN recall tuning.
- Add an evaluation task covering exact, filtered, and broad-search workloads.

## Type of Change

- [ ] New rule - Adding a new best practice rule
- [x] Rule improvement - Updating an existing rule
- [ ] New skill - Adding an entirely new skill
- [ ] Bug fix - Fixing an issue with existing content
- [ ] Documentation - Updating README, CONTRIBUTING, or other docs
- [ ] Build/Scripts - Changes to build process or scripts

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/AzureCosmosDB/cosmosdb-agent-kit/blob/main/CONTRIBUTING.md)
- [x] I ran `npm run validate` and it passed
- [x] My rule file follows the naming convention: `{prefix}-{description}.md`
- [x] My rule includes valid frontmatter (`title`, `impact`, `tags`)

## Agent Testing

- [ ] Tested with GitHub Copilot
- [ ] Tested with Claude Code
- [ ] Tested with Cursor
- [ ] Tested with other agent
- [x] N/A (documentation only)

## Related Issues

Addresses the Workstream 3 Rank 2 vector-indexing guidance audit item.

## Additional Notes

Validation completed locally:

- `npm run validate`: 136 rules validated, exit 0
- `npm run build`: 136 rules compiled, exit 0
- `git diff --check`: exit 0
- VS Code diagnostics: no errors in the changed rule or evaluation task

The generated `skills/cosmosdb-best-practices/AGENTS.md` was removed after the build and is not included. Vally was not installed, so the new task was not executed locally. `npm ci` could not contact the public npm registry from the managed development network (`ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE`); the repository scripts were run unchanged with locally available ignored dependencies, none of which are included in this branch.