### PR TITLE
feat(rule): add sdk-throughput-create-api

### DIFF
--- a/evals/cosmosdb-best-practices/tasks/sdk-throughput-create-api.yaml
+++ b/evals/cosmosdb-best-practices/tasks/sdk-throughput-create-api.yaml
@@ -1,0 +1,25 @@
+id: sdk-throughput-create-api
+name: SDK Best Practice - .NET ThroughputProperties factory-method parameter names
+description: |
+  Test that the skill knows ThroughputProperties.CreateAutoscaleThroughput's
+  parameter is named autoscaleMaxThroughput, not maxThroughput, and that
+  CreateManualThroughput's parameter is named throughput. Using the wrong
+  named argument fails to compile with CS1739.
+tags:
+  - sdk
+  - dotnet
+  - throughput
+  - api-surface
+  - build-error
+inputs:
+  prompt: |
+    I'm creating a Cosmos DB database in .NET with autoscale throughput and my
+    code doesn't compile:
+
+    ThroughputProperties.CreateAutoscaleThroughput(maxThroughput: 10000)
+
+    The error is CS1739: The best overload for 'CreateAutoscaleThroughput' does
+    not have a parameter named 'maxThroughput'. What's the correct parameter name?
+expected:
+  outcomes:
+    - type: task_completed

--- a/skills/cosmosdb-best-practices/SKILL.md
+++ b/skills/cosmosdb-best-practices/SKILL.md
@@ -129,6 +129,7 @@ Reference these guidelines when:
 - [sdk-langgraph-mcp-tool-filtering](rules/sdk-langgraph-mcp-tool-filtering.md) - Filter MCP tools by name prefix for per-agent assignment
 - [sdk-dotnet-namespace-collision](rules/sdk-dotnet-namespace-collision.md) - Avoid `Microsoft.Azure.Cosmos` namespace collisions with domain models (User, Database, Container, etc.)
 - [sdk-ingestion-rate-control](rules/sdk-ingestion-rate-control.md) - Rate-control high-volume ingestion (concurrency, retry-after, throughput control)
+- [sdk-throughput-create-api](rules/sdk-throughput-create-api.md) - Use `autoscaleMaxThroughput`/`throughput` parameter names for `ThroughputProperties` factory methods (.NET), not `maxThroughput`
 
 ### 5. Indexing Strategies (MEDIUM-HIGH)
 

--- a/skills/cosmosdb-best-practices/rules/sdk-throughput-create-api.md
+++ b/skills/cosmosdb-best-practices/rules/sdk-throughput-create-api.md
@@ -1,0 +1,46 @@
+---
+title: Use the correct parameter names for ThroughputProperties factory methods (.NET)
+impact: HIGH
+impactDescription: prevents CS1739 build-breaking named-argument errors
+tags: sdk, dotnet, throughput, api-surface, build-error, CS1739
+---
+
+## Use the Correct Parameter Names for ThroughputProperties Factory Methods (.NET)
+
+**Impact: HIGH (build-breaking)**
+
+The .NET SDK's `ThroughputProperties.CreateAutoscaleThroughput` takes a single `int` parameter named **`autoscaleMaxThroughput`**, not `maxThroughput`. `ThroughputProperties.CreateManualThroughput` takes a single `int` parameter named `throughput`. Passing either factory method a named argument with the wrong name fails to compile with **CS1739** ("the best overload does not have a parameter named ...").
+
+**Incorrect (CS1739 — no parameter named `maxThroughput`):**
+
+```csharp
+var databaseResponse = await client.CreateDatabaseIfNotExistsAsync(
+    databaseName,
+    throughputProperties: ThroughputProperties.CreateAutoscaleThroughput(
+        maxThroughput: 10000
+    ));
+```
+
+**Correct (named argument):**
+
+```csharp
+var databaseResponse = await client.CreateDatabaseIfNotExistsAsync(
+    databaseName,
+    throughputProperties: ThroughputProperties.CreateAutoscaleThroughput(
+        autoscaleMaxThroughput: 10000
+    ));
+
+// Manual throughput
+var manualThroughputProperties = ThroughputProperties.CreateManualThroughput(
+    throughput: 400
+);
+```
+
+**Also correct (positional argument avoids the naming pitfall entirely):**
+
+```csharp
+ThroughputProperties.CreateAutoscaleThroughput(10000);
+ThroughputProperties.CreateManualThroughput(400);
+```
+
+Reference: [ThroughputProperties.CreateAutoscaleThroughput — .NET API](https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.throughputproperties.createautoscalethroughput)

--- a/skills/cosmosdb-best-practices/rules/throughput-autoscale.md
+++ b/skills/cosmosdb-best-practices/rules/throughput-autoscale.md
@@ -42,7 +42,7 @@ var containerProperties = new ContainerProperties
 await database.CreateContainerAsync(
     containerProperties,
     throughputProperties: ThroughputProperties.CreateAutoscaleThroughput(
-        maxThroughput: 10000));  // Scales 1,000-10,000 RU/s
+        autoscaleMaxThroughput: 10000));  // Scales 1,000-10,000 RU/s
 
 // Benefits:
 // - Quiet period: Scales down to 1,000 RU/s (10% of max)
@@ -62,7 +62,7 @@ Console.WriteLine($"Current: {throughputResponse.Resource.Throughput} RU/s");
 ```csharp
 // Modify autoscale max throughput
 await container.ReplaceThroughputAsync(
-    ThroughputProperties.CreateAutoscaleThroughput(maxThroughput: 20000));
+    ThroughputProperties.CreateAutoscaleThroughput(autoscaleMaxThroughput: 20000));
 // Now scales between 2,000-20,000 RU/s
 ```
 

--- a/skills/cosmosdb-best-practices/rules/throughput-burst.md
+++ b/skills/cosmosdb-best-practices/rules/throughput-burst.md
@@ -53,7 +53,7 @@ await database.CreateContainerAsync(props, throughput: 1500);
 await database.CreateContainerAsync(
     props,
     throughputProperties: ThroughputProperties.CreateAutoscaleThroughput(
-        maxThroughput: 2000));  // Scales 200-2000 RU/s
+        autoscaleMaxThroughput: 2000));  // Scales 200-2000 RU/s
 
 // Burst is for:
 // - Momentary spikes (seconds to a few minutes)


### PR DESCRIPTION
## Description

Adds a new rule pinning the exact parameter names for `ThroughputProperties.CreateAutoscaleThroughput` (`autoscaleMaxThroughput`) and `CreateManualThroughput` (`throughput`) in the .NET SDK. The rule content and reproduction data are taken directly from the issue, which had already verified the signatures by reflection against `Microsoft.Azure.Cosmos` v3.59.0 and measured the failure rate across 53 generated projects.

## Type of Change

- [x] 📝 New rule - Adding a new best practice rule

## Checklist

- [x] I have read the Contributing Guide
- [x] I ran `npm run validate` and it passed
- [x] My rule file follows the naming convention: `{prefix}-{description}.md`
- [x] My rule includes valid frontmatter (`title`, `impact`, `tags`)

## For New Rules

**Rule file:** `skills/cosmosdb-best-practices/rules/sdk-throughput-create-api.md`

**Category:** SDK Best Practices

**Impact level:** High

**Why is this rule important?**

When a model names the argument to `CreateAutoscaleThroughput`, it consistently guesses `maxThroughput` instead of the actual parameter name `autoscaleMaxThroughput`, producing a deterministic CS1739 build break with no existing rule to prevent it. Per the issue: 12/12 named-argument calls across a 53-project sample used the wrong name.

## Agent Testing

- [ ] Tested with GitHub Copilot
- [ ] Tested with Claude Code
- [ ] Tested with Cursor
- [ ] N/A (documentation only)

Ran `npm run validate:skill cosmosdb-best-practices` (137/137 rules pass) and `npm run build:skill cosmosdb-best-practices` to confirm the rule compiles into `AGENTS.md` correctly. Did not run a live agent session against it.

## Related Issues

Fixes #155
